### PR TITLE
Add BaseWizardPage for common navigation handling

### DIFF
--- a/src/pages/BaseWizardPage.js
+++ b/src/pages/BaseWizardPage.js
@@ -1,0 +1,65 @@
+import React, { Component } from 'react';
+import '../Deployer.css';
+import { translate } from '../localization/localize.js';
+
+/**
+ * This base class handles the generic back and forward navigation that is common to
+ * most wizard pages.
+ */
+class BaseWizardPage extends Component {
+
+  /**
+   * function to determine whether the page is in an error state.  Subclasses 
+   * should override this and return true to prevent navigation
+   */
+  isError() {
+    return false;
+  }
+
+  /**
+  * function to go back a page, this depends on a callback function being passed
+  * into this class via props, and will call that function after any local changes
+  * @param {Event} the click event on the goBack button
+  */
+  goBack(e) {
+    e.preventDefault();
+    this.props.back(this.isError());
+  }
+
+  /**
+  * function to go forward a page, this depends on a callback function being passed
+  * into this class via props, and will call that function after any local changes
+  * This function should be where error checking occurs
+  * @param {Event} the click event on the goForward button
+  */
+  goForward(e) {
+    e.preventDefault();
+    this.props.next(this.isError());
+  }
+
+  renderNavButtons() {
+
+    let back = null;
+    if(this.props.back !== undefined) {
+      back= <button onClick={this.goBack.bind(this)}>
+        {translate('back')}
+      </button>;
+    }
+
+    let forward = null;
+    if(this.props.next !== undefined) {
+      forward = <button onClick={this.goForward.bind(this)}>
+        {translate('next')}
+      </button>;
+    }
+
+    return (
+      <div>
+        {back}
+        {forward}
+      </div>
+    );
+  }
+}
+
+export default BaseWizardPage;

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -1,33 +1,16 @@
 import React, { Component } from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';
+import GenericPlaceHolder from './GenericPlaceHolder';
 
-class CloudModelPicker extends Component {
-
-  goBack(e) {
-    e.preventDefault();
-    //if going back involved unsetting some parameters, do that here
-    this.props.back();
-  }
-
-  goForward(e) {
-    e.preventDefault();
-    //typical pages would do some validation here before deciding to advance
-    //however the intro page has no validation
-    this.props.next();
-  }
-
+class CloudModelPicker extends GenericPlaceHolder {
 
   render() {
     return (
       <div>
         {translate('model.picker.heading')}
-        <button onClick={this.goBack.bind(this)}>
-          {translate('back')}
-        </button>
-        <button onClick={this.goForward.bind(this)}>
-          {translate('next')}
-        </button>
+
+        {this.renderNavButtons()}
       </div>
     );
   }

--- a/src/pages/GenericPlaceHolder.js
+++ b/src/pages/GenericPlaceHolder.js
@@ -1,55 +1,20 @@
 import React, { Component } from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';
+import BaseWizardPage from './BaseWizardPage.js';
 
 /**
  * This is just a temporary placeholder component to show an example of a page that has
  * forward and back buttons in the wizard
  */
-class GenericPlaceHolder extends Component {
-
-  /**
-  * function to go back a page, this depends on a callback function being passed
-  * into this class via props, and will call that function after any local changes
-  * @param {Event} the click event on the goBack button
-  */
-  goBack(e) {
-    e.preventDefault();
-    //if going back involved unsetting some parameters, do that here
-    //if error checking on 'goBack' (not required) do so here
-    var isError = false;
-    this.props.back(isError);
-  }
-
-  /**
-  * function to go forward a page, this depends on a callback function being passed
-  * into this class via props, and will call that function after any local changes
-  * This function should be where error checking occurs
-  * @param {Event} the click event on the goForward button
-  */
-  goForward(e) {
-    e.preventDefault();
-    //typical pages would do some validation here before deciding to advance
-    var isError = false;
-    this.props.next(isError);
-  }
-
+class GenericPlaceHolder extends BaseWizardPage {
 
   render() {
-    let forward = null;
-    if(this.props.next !== undefined) {
-      forward = <button onClick={this.goForward.bind(this)}>
-        {translate('next')}
-      </button>;
-    }
 
     return (
       <div>
         {translate('generic.placeholder.heading')}
-        <button onClick={this.goBack.bind(this)}>
-          {translate('back')}
-        </button>
-        {forward}
+        {this.renderNavButtons()}
       </div>
     );
   }

--- a/src/pages/InstallIntro.js
+++ b/src/pages/InstallIntro.js
@@ -1,23 +1,15 @@
 import React, { Component } from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';
+import GenericPlaceHolder from './GenericPlaceHolder';
 
-class InstallIntro extends Component {
-
-  goForward(e) {
-    e.preventDefault();
-    //typical pages would do some validation here before deciding to advance
-    //however the intro page has no validation
-    this.props.next();
-  }
+class InstallIntro extends GenericPlaceHolder {
 
   render() {
     return (
       <div>
         {translate('welcome.cloud.install')}
-        <button onClick={this.goForward.bind(this)}>
-          {translate('next')}
-        </button>
+        {this.renderNavButtons()}
       </div>
     );
   }


### PR DESCRIPTION
Introduce the BaseWizardPage as a common base class for handling the
common back and forward navigation that will be common to most wizard
pages.  Change existing pages to use BaseWizard as their base class.