### PR TITLE
Add tox install to readme, serve UI on all IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 The cloud installer that will reside with SUSE Manager
 
 ## How to run
-Move to the root of the project and run `npm install` which will install all dependencies
+Move to the root of the project and run `npm install` which will install most dependencies
 
 Install `json-server` globally with `sudo npm install json-server -g`
+
+Install tox via pip:  `pip install tox`
 
 After that, run `npm start` which will bundle the react app and start the express server
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "protractor-setup": "./node_modules/protractor/bin/webdriver-manager update",
     "protractor": "./node_modules/protractor/bin/protractor protractor.conf.js",
     "less": "./node_modules/.bin/lessc ./src/styles/deployer.less ./src/Deployer.css",
-    "webdev": " webpack-dev-server --port 3000 --hot",
+    "webdev": " webpack-dev-server --port 3000 --hot --host 0.0.0.0",
     "jsonserv": "json-server --port 8080 api/api.json --watch",
     "watchless": "watch-run -p '**/*.less' npm run less",
     "shim": "tox -c server -e runserver"


### PR DESCRIPTION
adds a line to tell users to install tox via pip to get the UI to work fully
serves up the UI on all available IPs via 0.0.0.0 rather than just localhost