### PR TITLE
Improve log viewer performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "immutable": "^3.8.1",
     "json-loader": "^0.5.7",
     "json-server": "^0.11.2",
+    "lodash": "^4.17.4",
     "react": "^15.6.1",
     "react-bootstrap": "^0.31.2",
     "react-dom": "^15.6.1",

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -13,6 +13,7 @@
     "ok": "OK",
     "openstack.cloud.deployer.title": "SUSE Openstack Cloud Deployer",
     "wizard.loading.pleasewait": "Loading... Please wait",
+    "logviewer.autoscroll": "Automatically scroll to the bottom",
 
     "install.intro.message.body1": "You are about to install a new cloud.",
     "install.intro.message.body2": "You will need to supply information about the servers, networks and storage that will make up your cloud. The Openstack Cloud installer will then take care of deploying and configuring your new cloud for you.",

--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -111,20 +111,20 @@ class Progress extends BaseWizardPage {
         {this.renderHeading(translate('deploy.progress.heading'))}
         <div className='deploy-progress'>
           <div className='progress-body'>
-            <div className='col-xs-6'>
+            <div className='col-xs-4'>
               <ul>{this.getProgress()}</ul>
+              <div>
+                <ActionButton
+                  displayLabel='Progress'
+                  hasNext
+                  clickAction={() => this.progressing()}/>
+                {this.renderLogButton()}
+              </div>
             </div>
-            <div className='col-xs-6'>
+            <div className='col-xs-8'>
               {this.state.showLog ? <LogViewer playId={this.state.playId} /> : ''}
             </div>
           </div>
-        </div>
-        <div>
-          <ActionButton
-            displayLabel='Progress'
-            hasNext
-            clickAction={() => this.progressing()}/>
-          {this.renderLogButton()}
         </div>
         {this.renderNavButtons()}
       </div>

--- a/src/styles/components/logviewer.less
+++ b/src/styles/components/logviewer.less
@@ -1,5 +1,9 @@
 .log-viewer {
-  font-family: monospace;
-  min-height: 38em;
   min-width: 45em;
+  min-height: 45em;
+  pre {
+    min-height: 45em;
+    max-height: 45em;
+    overflow: auto;
+  }
 }


### PR DESCRIPTION
Convert to a <pre> since it does not accept user input.  Use
lodash.debounce to throttle the frequency of updates.  Properly
disconnect and cleanup when component is dismounted.  Add an autoscroll
checkbox.