### PR TITLE
Persist play id state

### DIFF
--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -2,16 +2,24 @@ import React, { Component } from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';
 
+// TODO(gary): Refactor BackButton and NextButton to inherit a common ancestor
 class BackButton extends Component {
   constructor(props) {
     super(props);
   }
   render() {
     let buttonClass = 'btn btn-primary btn-has-next';
+    buttonClass =
+      this.props.isDisabled ? buttonClass + ' ' + 'disabled' : buttonClass;
+
+    let buttonLabel = translate('back');
+    if (this.props.displayLabel) {
+      buttonLabel = this.props.displayLabel;
+    }
 
     return (
-      <button className={buttonClass} onClick={this.props.clickAction}>
-        {translate('back')}
+      <button className={buttonClass} onClick={this.props.clickAction}
+        disabled={this.props.isDisabled}>{buttonLabel}
       </button>
     );
   }

--- a/src/pages/BaseWizardPage.js
+++ b/src/pages/BaseWizardPage.js
@@ -51,11 +51,23 @@ class BaseWizardPage extends Component {
     return false;
   }
 
+  setBackButtonLabel() {
+    return null;
+  }
+
+  setBackButtonDisabled() {
+    return false;
+  }
+
   renderNavButtons() {
 
     let back = null;
     if(this.props.back !== undefined) {
-      back= <BackButton clickAction={this.goBack.bind(this)}/>;
+      back= <BackButton
+        clickAction={this.goBack.bind(this)}
+        displayLabel={this.setBackButtonLabel()}
+        isDisabled={this.setBackButtonDisabled()}
+      />;
     }
 
     let forward = null;

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -36,7 +36,6 @@ class CloudModelPicker extends BaseWizardPage {
     this.handleHelpChoose = this.handleHelpChoose.bind(this);
     this.handleShowSelectTemplateHelp = this.handleShowSelectTemplateHelp.bind(this);
     this.handleShowHelpChooseHelp = this.handleShowHelpChooseHelp.bind(this);
-    this.updateParentSelectedModelName = this.updateParentSelectedModelName.bind(this);
     this.handleCloseMessageAction = this.handleCloseMessageAction.bind(this);
   }
 
@@ -141,8 +140,8 @@ class CloudModelPicker extends BaseWizardPage {
     }
   }
 
-  updateParentSelectedModelName(modelName) {
-    this.props.updateModelName(modelName);
+  updateParentSelectedModelName = (modelName) => {
+    this.props.updateGlobalState('selectedModelName', modelName);
   }
 
   setNextButtonDisabled() {
@@ -178,7 +177,7 @@ class CloudModelPicker extends BaseWizardPage {
     //TODO
   }
 
-  handleCloseMessageAction ()  {
+  handleCloseMessageAction () {
     this.setState({showError: false});
   }
 


### PR DESCRIPTION
Include the deployment play id in the overall application state,
including persisting to and restoring from the progress.  Modified
top-level state handling to be more generic so that additional overall
state variables can more easily be included.  Manage visibility of
next/back buttons in the deployment progress page based on deployment
state Immediately persist the state when first loading if the state is
being reset or being loaded the first time.