### PR TITLE
Use playbook API for completed playbooks

### DIFF
--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -232,6 +232,18 @@ class CloudDeployProgress extends BaseWizardPage {
             this.logsReceived = List(message);
             this.setState({displayedLogs: this.logsReceived});
           })
+
+          this.fetchJson('http://localhost:8081/api/v1/clm/plays/' + this.props.sitePlayId + "/events")
+          .then(response => {
+            for (let evt of response) {
+              if (evt.event === 'playbook-stop')
+                this.playbookStopped(evt.playbook);
+              else if (evt.event === 'playbook-start')
+                this.playbookStarted(evt.playbook);
+              else if (evt.event === 'playbook-error')
+                this.playbookError(evt.playbook);
+            }
+          })
         } else {
           // The play is still in progress
           this.setState({deployStatus: DEPLOY_IN_PROGRESS});


### PR DESCRIPTION
When a playbook has completed, the deployment progress page can retrieve
and replacy events so that the page is rendered correctly