### PR TITLE
SCRD-1310 - add drag and drop support for server assignment

### DIFF
--- a/src/components/ServerRowItem.js
+++ b/src/components/ServerRowItem.js
@@ -6,6 +6,23 @@ class ServerRowItem extends Component {
     super(props);
   }
 
+  /**
+   * drag and drop support for server assignment, assigns the current set of data properties
+   * to the dataTransfer (payload) of the drag event so it can be picked up by the drop handler
+   *
+   * @param {event} ev the browser onDragStart event object
+   * @param {Object} dataDef the server data definition (keys primarily)
+   * @param {Object} data the server data payload
+   */
+  drag(ev, dataDef, data) {
+    dataDef.map(function (key, value) {
+      ev.dataTransfer.setData(key.name, data[key.name]);
+    });
+    //setData only supports strings, JSON stringify here, parse on the other end
+    ev.dataTransfer.setData("dataDef", JSON.stringify(dataDef));
+    ev.dataTransfer.setData("data", JSON.stringify(data));
+  }
+
   handleCustomAction = (data) => {
     if(this.props.customAction) {
       this.props.customAction(data);
@@ -39,7 +56,8 @@ class ServerRowItem extends Component {
   render() {
     if(this.props.tableId === 'right') {
       return (
-        <tr className='table-row'>
+        <tr className='table-row'
+          draggable="true" onDragStart={(event) => this.drag(event, this.props.dataDef, this.props.data)}>
           {this.renderServerColumns()}
           <EditPencilForTableRow
             clickAction={(e) => this.handleCustomAction(this.props.data)}>
@@ -49,7 +67,10 @@ class ServerRowItem extends Component {
     }
     else {
       return (
-        <tr className='table-row'>{this.renderServerColumns()}</tr>
+        <tr className='table-row'
+          draggable="true" onDragStart={(event) => this.drag(event, this.props.dataDef, this.props.data)}>
+          {this.renderServerColumns()}
+        </tr>
       );
     }
   }

--- a/src/components/ServerUtils.js
+++ b/src/components/ServerUtils.js
@@ -104,13 +104,18 @@ class ServerRolesAccordion extends Component {
       }
       let isOpen = idx === this.state.accordionPosition;
       return (
-        <Collapsible
-          open={isOpen}
-          trigger={optionDisplay.join(' ')} key={role.name}
-          handleTriggerClick={() => this.handleTriggerClick(idx, role)}
-          value={role.serverRole}>
-          {isOpen && this.renderAccordionServerTable()}
-        </Collapsible>
+        <span
+          onDrop={(event) => this.props.ondropFunct(event, role.serverRole)}
+          onDragOver={(event) => this.props.allowDropFunct(event, role.serverRole)}
+          key={role.name}>
+          <Collapsible
+            open={isOpen}
+            trigger={optionDisplay.join(' ')} key={role.name}
+            handleTriggerClick={() => this.handleTriggerClick(idx, role)}
+            value={role.serverRole}>
+            {isOpen && this.renderAccordionServerTable()}
+          </Collapsible>
+        </span>
       );
     });
 


### PR DESCRIPTION
Adds support for drag and drop server assignments from both manual and automatically discovered server tables. 

known issues:
I'm seeing mixed results on manually added servers will still showing in the left side table even after added to a role ... in the failure case it was because the server did not define an "id" (rather it had a "name") , which is expected to change in an upcoming commit to match the agreed upon scheme... it worked for me later though, so I'm unclear on the overall status

styling for dragged items is not great, I'll work on that next