### PR TITLE
Make string formatting sane

### DIFF
--- a/src/components/ServerUtils.js
+++ b/src/components/ServerUtils.js
@@ -114,7 +114,7 @@ class ServerRolesAccordion extends Component {
           key={role.name}>
           <Collapsible
             open={isOpen}
-            trigger={optionDisplay.join(' ')} key={role.name}
+            trigger={optionDisplay} key={role.name}
             handleTriggerClick={() => this.handleTriggerClick(idx, role)}
             value={role.serverRole}>
             {isOpen && this.renderAccordionServerTable()}
@@ -258,7 +258,7 @@ class ServerInput extends Component {
 
 class ServerInputLine extends Component {
   render() {
-    let labelStr = translate(this.props.label).toString();
+    let labelStr = translate(this.props.label);
     let label = (this.props.isRequired) ? labelStr + '*' : labelStr;
     return (
       <div className='detail-line'>
@@ -324,7 +324,7 @@ class ServerDropdown extends Component {
 
 class ServerDropdownLine extends Component {
   render() {
-    let labelStr = translate(this.props.label).toString();
+    let labelStr = translate(this.props.label);
     let label = (this.props.isRequired) ? labelStr + '*' : labelStr;
     return (
       <div className='detail-line'>

--- a/src/localization/localize.js
+++ b/src/localization/localize.js
@@ -21,5 +21,8 @@ for (i = 0; i < window.navigator.languages.length; i++) {
 }
 
 export function translate(key, ...args) {
-  return strings.formatString(strings[key], ...args);
+  // Note!
+  // For some bizarre reason, strings.formatString returns an array of strings rather than a single string.
+  // The join() corrects this by joining the elements into a signle string.
+  return strings.formatString(strings[key], ...args).join('');
 }


### PR DESCRIPTION
The react string formatting utility incorrectly returns a list of
strings.  Adjusted the wrapper around it to convert it to a single
string and remove various work-arounds to deal with that.