### PR TITLE
move toast message back to top of its content parent

### DIFF
--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -1451,6 +1451,7 @@ class AssignServerRoles extends BaseWizardPage {
   render() {
     return (
       <div className='wizard-page'>
+        {this.renderErrorMessage()}
         <div id='AssignServerRoleId' className='wizard-content'>
           {this.renderHeading(translate('add.server.heading', this.props.model.get('name')))}
           {this.renderServerRoleContent()}
@@ -1458,7 +1459,6 @@ class AssignServerRoles extends BaseWizardPage {
           {this.renderAddServerManuallyModal()}
           {this.renderEditServerDetailsModal()}
           {this.renderLoadingMask()}
-          {this.renderErrorMessage()}
         </div>
       {this.renderNavButtons()}
       </div>

--- a/src/styles/components/messages.less
+++ b/src/styles/components/messages.less
@@ -3,6 +3,9 @@
 .notification-message {
   z-index: 1111;
   min-width: 35em;
+  position: fixed;
+  width: 98%;
+  left: 1%;
 }
 
 .notification-message-container {


### PR DESCRIPTION
the error toasts had been accidentally moved to the bottom of the content pages, this fixes that issue