### PR TITLE
Simplify LoadingMask

### DIFF
--- a/src/components/LoadingMask.js
+++ b/src/components/LoadingMask.js
@@ -2,27 +2,18 @@ import React, { Component } from 'react';
 import { ThreeBounce } from 'better-react-spinkit';
 import '../Deployer.css';
 
-class LoadingMask extends Component {
-  renderMask() {
-    let retValue = <div></div>;
-    let spinSize = this.props.size ? this.props.size : 25;
-    if(this.props.show) {
-      let cName = 'spinners-container ';
-      cName = this.props.className ? cName + this.props.className : cName;
-      retValue = (
-        <div className={cName}>
-          <ThreeBounce className='spinners' size={spinSize} color='#00C081'/>
-        </div>
-      );
-    }
-    return retValue;
-  }
+function LoadingMask(props) {
+  if (! props.show)
+    return null;
 
-  render() {
-    return (
-      <div>{this.renderMask()}</div>
-    );
-  }
+  return (
+    <div className={'spinners-container ' + (props.className || '')}>
+      <ThreeBounce 
+        className='spinners'
+        size={props.size || 25}
+        color='#00C081'/>
+    </div>
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
Simplify the LoadingMask by converting it to a functional component and
returning null when it is not going to be displayed instead of two
nested empty divs.