### PR TITLE
Add support for running os provision playbook

### DIFF
--- a/src/components/WizardProgress.js
+++ b/src/components/WizardProgress.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { stepProgressValues } from './../utils/StepProgressValues.js';
+import { STATUS } from './../utils/constants.js';
 
 /**
  * Progress indicator showing the user how far along in the wizard they are
@@ -10,15 +10,15 @@ class WizardProgress extends Component {
   render()
   {
     var stateBubbles = this.props.steps.map(function(item,index) {
-      if(item.stepProgress === stepProgressValues.done) {
+      if(item.stepProgress === STATUS.COMPLETE) {
         return (
           <span key={index} className="progress done"/>
         );
-      } else if(item.stepProgress === stepProgressValues.inprogress) {
+      } else if(item.stepProgress === STATUS.IN_PROGRESS) {
         return (
           <span key={index} className="progress in-progress"/>
         );
-      } else if(item.stepProgress === stepProgressValues.error) {
+      } else if(item.stepProgress === STATUS.FAILED) {
         return (
           <span key={index} className="progress error"/>
         );

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -206,7 +206,6 @@
     "complete.message.body": "Some post deploy instruction contents here...",
 
     "deploy.progress.heading": "Cloud Deployment In Progress",
-    "deploy.progress.failure": "Deployment Failure : {0}",
     "deploy.progress.step1": "Network Configuration",
     "deploy.progress.step2": "Compute nodes deployed",
     "deploy.progress.step3": "Monitoring nodes deployed",
@@ -214,8 +213,16 @@
     "deploy.progress.step5": "Quick health check",
     "deploy.progress.step6": "Additional Setup and Configuration",
     "deploy.progress.step7": "n/a",
-    "deploy.progress.show.log": "Show Log",
-    "deploy.progress.hide.log": "Hide Log",
+
+    "install.progress.heading": "SLES Installation In Progress",
+    "install.progress.step1": "Verify IPMI Connectivity",
+    "install.progress.step2": "Install and Configure Cobbler",
+    "install.progress.step3": "Provision SLES",
+    "install.progress.step4": "Additional Setup and Configuration",
+
+    "progress.failure": "Failure",
+    "progress.show.log": "Show Log",
+    "progress.hide.log": "Hide Log",
 
     "provision.server.heading": "Choose servers on which SLES will be installed",
     "provision.server.left.table": "Available Servers",

--- a/src/styles/components/playbookprogress.less
+++ b/src/styles/components/playbookprogress.less
@@ -1,4 +1,4 @@
-.deploy-progress {
+.playbook-progress {
   ul {
     list-style-type: none;
     line-height: 2.5em;

--- a/src/styles/deployer.less
+++ b/src/styles/deployer.less
@@ -7,7 +7,7 @@
 @import "components/installintro.less";
 @import "components/modelpicker.less";
 @import "components/ymlvalidator.less";
-@import "components/deployprogress.less";
+@import "components/playbookprogress.less";
 @import "components/buttons.less";
 @import "components/svrroleassigner.less";
 @import "components/serverprovision.less";

--- a/src/utils/StepProgressValues.js
+++ b/src/utils/StepProgressValues.js
@@ -1,6 +1,0 @@
-export const stepProgressValues = {
-  'notdone': 0,
-  'done': 1,
-  'inprogress': 2,
-  'error': 3
-};

--- a/src/utils/WizardDefaults.js
+++ b/src/utils/WizardDefaults.js
@@ -27,11 +27,11 @@ export const pages = [{
   name: 'AssignServerRoles',
   component: AssignServerRoles
 }, {
-  name: 'ServerRoleSummary',
-  component: ServerRoleSummary
-}, {
   name: 'SelectServersToProvision',
   component: SelectServersToProvision
+}, {
+  name: 'ServerRoleSummary',
+  component: ServerRoleSummary
 }, {
   name: 'ValidateConfigFiles',
   component: ValidateConfigFiles

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,7 @@
+export const STATUS = {
+  UNKNOWN: -1,
+  NOT_STARTED: 0,
+  COMPLETE: 1,
+  IN_PROGRESS: 2,
+  FAILED: 3
+};


### PR DESCRIPTION
Refactor CloudDeploy to permit re-using the log viewer portion in more
than one place, changing 'deploy' to more generic terms .  Combine
status values and put them in a single place.