### PR TITLE
Add /lib to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /dist
 /public
 /*.tar
+/lib
 
 # generated files
 src/Deployer.css
@@ -30,3 +31,4 @@ yarn-error.log*
 *.iml
 .idea
 tools/.inspecrc
+


### PR DESCRIPTION
webpack creates the /lib dir and puts fonts there, so exclude it from
git tracking