### PR TITLE
prevent backwards navigation via sidebar for final 2 wizard steps

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -332,7 +332,8 @@ class InstallWizard extends Component {
             this.state.steps.map((item, index) => {
               let stepClass = 'stepItem';
               let onClickFnct = undefined;
-              if(this.state.currentStep > index) {
+              if(this.state.currentStep > index &&
+                 this.state.currentStep < (this.props.pages.length - 2)) {
                 stepClass = 'stepItem prevstep';
                 onClickFnct = () => {
                   this.stepTo(index);


### PR DESCRIPTION
fixes bug where users could use the left side navigation to go back after having already deployed. For now just prevents backwards nav if the user is on the last two steps, since propagating up next/back-allowed status would take a bit of redesign and the left side nav may not survive UX review