### PR TITLE
Add apache license to code files per legal review

### DIFF
--- a/build_dist.sh
+++ b/build_dist.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # build the neccessary UI files
 ./build_ui.sh

--- a/build_ui.sh
+++ b/build_ui.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 TARBALL=false
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import { AppContainer } from 'react-hot-loader';
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/run_dist.sh
+++ b/run_dist.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # package the server and UI components into the right folder
 ./build_dist.sh

--- a/server.js
+++ b/server.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 //dev server for running the mock backend
 //run with "node server.js" in terminal
 

--- a/server/config/config.py
+++ b/server/config/config.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from ConfigParser import SafeConfigParser
 import logging
 import os

--- a/server/main.py
+++ b/server/main.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from config import config
 from flask import Flask
 from flask_cors import CORS

--- a/server/manager_cloud_installer_svr/__init__.py
+++ b/server/manager_cloud_installer_svr/__init__.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from eventlet import monkey_patch as monkey_patch
 from flask_socketio import SocketIO
 # IMPORTANT!

--- a/server/manager_cloud_installer_svr/ardana.py
+++ b/server/manager_cloud_installer_svr/ardana.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from . import util
 import config.config as config
 from flask import Blueprint

--- a/server/manager_cloud_installer_svr/oneview.py
+++ b/server/manager_cloud_installer_svr/oneview.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import config.config as config
 from flask import abort
 from flask import Blueprint

--- a/server/manager_cloud_installer_svr/socket_proxy.py
+++ b/server/manager_cloud_installer_svr/socket_proxy.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from . import socketio
 import config.config as config
 import eventlet

--- a/server/manager_cloud_installer_svr/suse_manager.py
+++ b/server/manager_cloud_installer_svr/suse_manager.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 from . import util
 import config.config as config
 from flask import abort

--- a/server/manager_cloud_installer_svr/ui.py
+++ b/server/manager_cloud_installer_svr/ui.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import config.config as config
 from flask import abort
 from flask import Blueprint

--- a/server/manager_cloud_installer_svr/util.py
+++ b/server/manager_cloud_installer_svr/util.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import config.config as config
 import requests
 import socket

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Hewlett-Packard Development Company, L.P.
+# (c) Copyright 2017 SUSE LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -8,10 +8,10 @@
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-# implied.
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 
 # THIS FILE IS MANAGED BY THE GLOBAL REQUIREMENTS REPO - DO NOT EDIT
 import setuptools

--- a/src/Deployer.js
+++ b/src/Deployer.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import './Deployer.css';
 import InstallWizard from './InstallWizard';

--- a/src/Deployer.test.js
+++ b/src/Deployer.test.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 /* global it */
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import './Deployer.css';
 import { translate } from './localization/localize.js';

--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';

--- a/src/components/CollapsibleTable.js
+++ b/src/components/CollapsibleTable.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import '../Deployer.css';
 

--- a/src/components/ContextMenu.js
+++ b/src/components/ContextMenu.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import ReactDOM from 'react-dom';
 import '../Deployer.css';

--- a/src/components/InlineAddRemoveFields.js
+++ b/src/components/InlineAddRemoveFields.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { ServerInput, ServerDropdown } from '../components/ServerUtils.js';
 

--- a/src/components/LoadingMask.js
+++ b/src/components/LoadingMask.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import { ThreeBounce } from 'better-react-spinkit';
 import '../Deployer.css';

--- a/src/components/Messages.js
+++ b/src/components/Messages.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { Alert } from 'react-bootstrap';
 import { translate } from '../localization/localize.js';

--- a/src/components/Modals.js
+++ b/src/components/Modals.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import { Modal } from 'react-bootstrap';
 import { ActionButton } from '../components/Buttons.js';

--- a/src/components/ServerRowItem.js
+++ b/src/components/ServerRowItem.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { EditPencilForTableRow , InfoForTableRow} from './Buttons.js';
 

--- a/src/components/ServerTable.js
+++ b/src/components/ServerTable.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
 import ServerRowItem from './ServerRowItem.js';

--- a/src/components/ServerUtils.js
+++ b/src/components/ServerUtils.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import Collapsible from 'react-collapsible';
 import '../Deployer.css';

--- a/src/components/TransferTable.js
+++ b/src/components/TransferTable.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import '../Deployer.css';
 import { AssignmentButton } from '../components/Buttons.js';

--- a/src/components/WizardProgress.js
+++ b/src/components/WizardProgress.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { STATUS } from './../utils/constants.js';
 

--- a/src/localization/localize.js
+++ b/src/localization/localize.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import LocalizedStrings from 'react-localization';
 
 var supportedLangs = ['en', 'ja'];

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import '../Deployer.css';
 import Cookies from 'universal-cookie';

--- a/src/pages/AssignServerRoles/BaseServerDetails.js
+++ b/src/pages/AssignServerRoles/BaseServerDetails.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { Tabs, Tab } from 'react-bootstrap';
 import { translate } from '../../localization/localize.js';

--- a/src/pages/AssignServerRoles/ConnectionCredsInfo.js
+++ b/src/pages/AssignServerRoles/ConnectionCredsInfo.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { ServerInputLine } from '../../components/ServerUtils.js';

--- a/src/pages/AssignServerRoles/EditServerDetails.js
+++ b/src/pages/AssignServerRoles/EditServerDetails.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { ActionButton } from '../../components/Buttons.js';

--- a/src/pages/AssignServerRoles/ModelServerDetails.js
+++ b/src/pages/AssignServerRoles/ModelServerDetails.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 

--- a/src/pages/AssignServerRoles/OvServerDetails.js
+++ b/src/pages/AssignServerRoles/OvServerDetails.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import { translate } from '../../localization/localize.js';
 import BaseServerDetails from './BaseServerDetails.js';

--- a/src/pages/AssignServerRoles/SmServerDetails.js
+++ b/src/pages/AssignServerRoles/SmServerDetails.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import { translate } from '../../localization/localize.js';
 import BaseServerDetails from './BaseServerDetails.js';

--- a/src/pages/AssignServerRoles/ViewServerDetails.js
+++ b/src/pages/AssignServerRoles/ViewServerDetails.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { ActionButton } from '../../components/Buttons.js';

--- a/src/pages/BaseWizardPage.js
+++ b/src/pages/BaseWizardPage.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import '../Deployer.css';
 //import { translate } from '../localization/localize.js';

--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 
 import { translate } from '../localization/localize.js';

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import { fromJS } from 'immutable';
 import '../Deployer.css';

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';

--- a/src/pages/Complete.js
+++ b/src/pages/Complete.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';

--- a/src/pages/GenericPlaceHolder.js
+++ b/src/pages/GenericPlaceHolder.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';

--- a/src/pages/InstallIntro.js
+++ b/src/pages/InstallIntro.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';

--- a/src/pages/SelectServersToProvision.js
+++ b/src/pages/SelectServersToProvision.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 
 import { translate } from '../localization/localize.js';

--- a/src/pages/ServerRoleSummary.js
+++ b/src/pages/ServerRoleSummary.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React from 'react';
 import { translate } from '../localization/localize.js';
 import BaseWizardPage from './BaseWizardPage.js';

--- a/src/pages/ServerRoleSummary/DiskModelsTab.js
+++ b/src/pages/ServerRoleSummary/DiskModelsTab.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { ActionButton } from '../../components/Buttons.js';

--- a/src/pages/ServerRoleSummary/EditCloudSettings.js
+++ b/src/pages/ServerRoleSummary/EditCloudSettings.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { Tabs, Tab } from 'react-bootstrap';

--- a/src/pages/ServerRoleSummary/InterfaceModelsTab.js
+++ b/src/pages/ServerRoleSummary/InterfaceModelsTab.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { ActionButton } from '../../components/Buttons.js';

--- a/src/pages/ServerRoleSummary/NetworksTab.js
+++ b/src/pages/ServerRoleSummary/NetworksTab.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import UpdateNetworks  from './UpdateNetworks.js';

--- a/src/pages/ServerRoleSummary/NicMappingTab.js
+++ b/src/pages/ServerRoleSummary/NicMappingTab.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { alphabetically } from '../../utils/Sort.js';

--- a/src/pages/ServerRoleSummary/ServerGroupDetails.js
+++ b/src/pages/ServerRoleSummary/ServerGroupDetails.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { fromJS } from 'immutable';
 import { translate } from '../../localization/localize.js';

--- a/src/pages/ServerRoleSummary/ServerGroupsTab.js
+++ b/src/pages/ServerRoleSummary/ServerGroupsTab.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../../localization/localize.js';
 import { ActionButton } from '../../components/Buttons.js';

--- a/src/pages/ServerRoleSummary/UpdateNetworks.js
+++ b/src/pages/ServerRoleSummary/UpdateNetworks.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { fromJS } from 'immutable';
 import { translate } from '../../localization/localize.js';

--- a/src/pages/ValidateConfigFiles.js
+++ b/src/pages/ValidateConfigFiles.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 
 import { translate } from '../localization/localize.js';

--- a/src/sandbox/ardanaServerList.js
+++ b/src/sandbox/ardanaServerList.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import React, { Component } from 'react';
 import { translate } from '../localization/localize.js';
 import BaseWizardPage from '../pages/BaseWizardPage';

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "palette";//palette.less
 @import url(//fonts.googleapis.com/css?family=Lato);
 

--- a/src/styles/components/buttons.less
+++ b/src/styles/components/buttons.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "./../palette.less";
 
 .btn {

--- a/src/styles/components/collapsibletable.less
+++ b/src/styles/components/collapsibletable.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 .collapsible-table {
   .group-row {
     border-bottom: 1px solid @box-border-color;

--- a/src/styles/components/contextmenu.less
+++ b/src/styles/components/contextmenu.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "./../palette.less";
 
 .context-menu-container {

--- a/src/styles/components/installintro.less
+++ b/src/styles/components/installintro.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 .installIntro {
   display: inline-block;
   .topLine {

--- a/src/styles/components/loadingmask.less
+++ b/src/styles/components/loadingmask.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "./../palette.less";
 
 .spinners-container {

--- a/src/styles/components/logviewer.less
+++ b/src/styles/components/logviewer.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 
 .log-viewer {
   position: relative;

--- a/src/styles/components/messages.less
+++ b/src/styles/components/messages.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "./../palette.less";
 
 .notification-message {

--- a/src/styles/components/modals.less
+++ b/src/styles/components/modals.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "./../palette.less";
 
 .modals {

--- a/src/styles/components/modelpicker.less
+++ b/src/styles/components/modelpicker.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "./../palette.less";
 
 .picker-container {

--- a/src/styles/components/playbookprogress.less
+++ b/src/styles/components/playbookprogress.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 .playbook-progress {
   ul {
     list-style-type: none;

--- a/src/styles/components/serverprovision.less
+++ b/src/styles/components/serverprovision.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 .server-provision {
   .button-container {
     margin-top: 2em;

--- a/src/styles/components/transfertable.less
+++ b/src/styles/components/transfertable.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 .transfer-table {
   display: flex;
   width: 100%;

--- a/src/styles/components/wizard.less
+++ b/src/styles/components/wizard.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "./../palette.less";
 
 .wizard-progress-container {

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 .validate-config-files {
   font-size: 1.1em;
   ul {

--- a/src/styles/deployer.less
+++ b/src/styles/deployer.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "../../node_modules/font-awesome/less/font-awesome.less";
 @fa-font-path: "../node_modules/font-awesome/fonts";
 @import "palette.less";

--- a/src/styles/fonts.less
+++ b/src/styles/fonts.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @font-face {
   font-family: 'Material Icons';
   font-style: normal;

--- a/src/styles/pages/AssignServerRoles.less
+++ b/src/styles/pages/AssignServerRoles.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @import "./../palette.less";
 
 /*

--- a/src/styles/pages/ServerRoleSummary.less
+++ b/src/styles/pages/ServerRoleSummary.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 .cloud-settings {
   .button-box {
     width: 100%;

--- a/src/styles/palette.less
+++ b/src/styles/palette.less
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 @productprimarycolor: #02D35F;
 
 @preferredcolor: #00C081;

--- a/src/utils/ConfigHelper.js
+++ b/src/utils/ConfigHelper.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 var appConfigs = {
   'shimurl': 'http://localhost:8081',
   'deployserviceurl': 'http://localhost:9085',

--- a/src/utils/CsvImporter.js
+++ b/src/utils/CsvImporter.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import Papa from 'papaparse';
 import { IpV4AddressValidator, MacAddressValidator } from './InputValidators.js';
 

--- a/src/utils/InputValidators.js
+++ b/src/utils/InputValidators.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import { translate } from '../localization/localize.js';
 
 const IPV4ADDRESS =

--- a/src/utils/RestUtils.js
+++ b/src/utils/RestUtils.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import { getAppConfig } from './ConfigHelper.js';
 
 /**

--- a/src/utils/Sort.js
+++ b/src/utils/Sort.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 export function alphabetically(a,b) {
   const x = a.toUpperCase();
   const y = b.toUpperCase();

--- a/src/utils/WizardDefaults.js
+++ b/src/utils/WizardDefaults.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 import CloudModelPicker from '../pages/CloudModelPicker';
 import CloudModelSummary from '../pages/CloudModelSummary';
 import AssignServerRoles from '../pages/AssignServerRoles';

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 export const STATUS = {
   UNKNOWN: -1,
   NOT_STARTED: 0,

--- a/test/e2e/specs/sanitycheck.spec.js
+++ b/test/e2e/specs/sanitycheck.spec.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 /* eslint no-undef: 0 */
 describe('basic sanity tests', function() {
 

--- a/tools/inspector.py
+++ b/tools/inspector.py
@@ -3,6 +3,18 @@
 # python -i inspector.py
 
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 # import ssl

--- a/tools/websoctest.py
+++ b/tools/websoctest.py
@@ -1,4 +1,16 @@
 # (c) Copyright 2017 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # Requires:
 #   https://pypi.python.org/pypi/websocket-client/
 #   pip install websocket-client

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,17 @@
 // (c) Copyright 2017 SUSE LLC
+/**
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+**/
 /* eslint no-unused-vars: 0 */
 var path = require('path');
 var webpack = require('webpack');


### PR DESCRIPTION
Legal review identified a couple of issues:
1. there was a file with an HP license
2. source files did not contain the apache license on a per file basis

both of these are remedied in this pull request, along with fixing the following warning that rpmlint found:
[   45s] cloud-install-ui.noarch: W: non-executable-script /opt/ardana/ansible/tools/inspector.py 0644L /usr/bin/python
[   45s] This text file contains a shebang or is located in a path dedicated for
[   45s] executables, but lacks the executable bits and cannot thus be executed.  If
[   45s] the file is meant to be an executable script, add the executable bits,
[   45s] otherwise remove the shebang or move the file elsewhere.