### PR TITLE
Add new shared Dropdown component

### DIFF
--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -36,6 +36,8 @@ import React from 'react';
  *
  *    </Dropdown>
  */
+const UNSET = 'unset';
+
 export default function Dropdown(props) {
 
   // Make a copy of props that can be modified to remove emptyOption and children
@@ -43,8 +45,10 @@ export default function Dropdown(props) {
   let myProps = Object.assign({}, props);
 
   let emptyItem;
-  if (props.emptyOption && props.value === undefined) {
-    emptyItem = <option key='undefined' value='undefined'>{props.emptyOption}</option>;
+  if (props.emptyOption && (props.value === undefined)) {
+    emptyItem = <option key={UNSET} value={UNSET}>{props.emptyOption}</option>;
+    // explicitly choose the row with emptyOption with props.value is undefined
+    myProps.value = UNSET;
   }
 
   const children = myProps.children;


### PR DESCRIPTION
The ServerDropdown component was originally designed for the ServerUtils
page but has been used in a number of places throughout the code base.
ServerDropdown has a couple of nice features, such as the ability to add
an extra row as an 'empty' option (when no option has yet been
selected), and it uses css classes that are styled to be consistent with
the rest of the application.  But ServerDropdown suffers from a number
of problems including:
- Non-standard api: the properties that you need to send to
  ServerDropdown are entirely different from the standard ones for a
  <select> component
- It supports both a 'default' and 'empty' option, which both attempt to
   provide the same feature in different ways
- It does not support building the option list and sending it as a child
   property (like <select> does)
- It attempts to manage the state (and props) of the component.  Since
  the parent component still has to track the state of the component,
  this extra level of tracking is unecessary.  Worse yet, this extra
  tracking logic interferes with, and sometimes breaks the overall
  logic.

Since the API of this component is different from ServerDropdown, this
component was added to the code base, rather than removing
ServerDropdown and cause a significant disruptive change.
ServerDropdown can be phased out and removed opportunistically.