### PR TITLE
explicitly compile less files prior to creating dist bundle

### DIFF
--- a/build_ui.sh
+++ b/build_ui.sh
@@ -26,7 +26,10 @@ done
 #erase the previous dist
 rm -rf dist
 
-#first build a bundle version of the javascript
+#compile the css/less files
+npm run less
+
+#build a bundle version of the javascript
 npm run dist
 
 #copy the production index.html to the dist folder


### PR DESCRIPTION
The build_ui script was not explicitly calling the less compilation prior to bundling up the bits... meaning in some cases the compiled css was out of date. 