### PR TITLE
prevents saving over the data model if no model selection has occurred

### DIFF
--- a/src/components/ServerUtils.js
+++ b/src/components/ServerUtils.js
@@ -17,7 +17,7 @@ import Collapsible from 'react-collapsible';
 import '../Deployer.css';
 import { translate } from '../localization/localize.js';
 import ServerTable from './ServerTable.js';
-import { isRoleAssignmentValid } from "../utils/ModelUtils.js";
+import { isRoleAssignmentValid } from '../utils/ModelUtils.js';
 
 export class SearchBar extends Component {
   constructor(props) {

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -31,7 +31,7 @@ import ViewServerDetails from './AssignServerRoles/ViewServerDetails';
 import { importCSV } from '../utils/CsvImporter.js';
 import { fromJS } from 'immutable';
 import { isEmpty } from 'lodash';
-import { getServerRoles, isRoleAssignmentValid,  getNicMappings, getServerGroups } from "../utils/ModelUtils.js";
+import { getServerRoles, isRoleAssignmentValid,  getNicMappings, getServerGroups } from '../utils/ModelUtils.js';
 
 const AUTODISCOVER_TAB = 1;
 const MANUALADD_TAB = 2;

--- a/src/pages/CloudModelPicker.js
+++ b/src/pages/CloudModelPicker.js
@@ -45,6 +45,8 @@ class CloudModelPicker extends BaseWizardPage {
       errorContent: undefined,
       loading: false
     };
+
+    this.saveRequired = false;
   }
 
   componentWillMount() {
@@ -71,26 +73,32 @@ class CloudModelPicker extends BaseWizardPage {
 
   handlePickModel = (e) => {
     this.setState({selectedModelName: e.target.getAttribute('name')});
+    this.saveRequired = true;
   }
 
   goForward = (e) => {
     e.preventDefault();
 
-    this.setState({loading: true});
-    // Load the full template, update the global model, and save it
-    fetchJson('/api/v1/clm/templates/' + this.state.selectedModelName)
-      .then(model => this.props.updateGlobalState('model', fromJS(model), this.props.next))
-      .catch(error => {
-        this.setState({
-          errorContent: {
-            title: translate('model.picker.save.model.error.title'),
-            messages: [
-              translate('model.picker.save.model.error', this.state.selectedModelName),
-              error.toString()]
-          },
-          loading: false
+    if(this.saveRequired) {
+      this.setState({loading: true});
+      // Load the full template, update the global model, and save it
+      fetchJson('/api/v1/clm/templates/' + this.state.selectedModelName)
+        .then(model => this.props.updateGlobalState('model', fromJS(model), this.props.next))
+        .catch(error => {
+          this.setState({
+            errorContent: {
+              title: translate('model.picker.save.model.error.title'),
+              messages: [
+                translate('model.picker.save.model.error', this.state.selectedModelName),
+                error.toString()]
+            },
+            loading: false
+          });
         });
-      });
+      this.saveRequired = false;
+    } else {
+      this.props.next();
+    }
   }
 
   handleSelectTemplate = (e) => {

--- a/src/pages/ServerRoleSummary.js
+++ b/src/pages/ServerRoleSummary.js
@@ -19,7 +19,7 @@ import CollapsibleTable from './ServerRoleSummary/CollapsibleTable.js';
 import { ActionButton } from '../components/Buttons.js';
 import { EditCloudSettings } from './ServerRoleSummary/EditCloudSettings.js';
 import { fromJS } from 'immutable';
-import { getServerRoles, isRoleAssignmentValid } from "../utils/ModelUtils.js";
+import { getServerRoles, isRoleAssignmentValid } from '../utils/ModelUtils.js';
 
 class ServerRoleSummary extends BaseWizardPage {
 


### PR DESCRIPTION
resolves an issue where if the user had navigated forward and done server assignments, then went back to the picker page and didn't change the model, they would lose their assignments when they navigated forward again.