### PR TITLE
add npm install to build script so it works in clean environments

### DIFF
--- a/build_ui.sh
+++ b/build_ui.sh
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# install npm dependencies to run the build
+npm install
+
 TARBALL=false
 
 # if -t is specified, build a tarball of the UI bits


### PR DESCRIPTION
in a clean environment the web content was not getting populated into the tarball... discovered when the automatically built tarballs were missing the "web" folder content