### PR TITLE
change shim default port to 8081 rather than window.location.port for…

### DIFF
--- a/src/utils/ConfigHelper.js
+++ b/src/utils/ConfigHelper.js
@@ -13,7 +13,7 @@
 * limitations under the License.
 **/
 var appConfigs = {
-  'shimurl': window.location.protocol + '//' + window.location.hostname + ':' + window.location.port,
+  'shimurl': window.location.protocol + '//' + window.location.hostname + ':' + 8081,
   //remove this when release
   'dev': true
 };


### PR DESCRIPTION
change shim default port to 8081 rather than window.location.port for now

using window.location.port is more flexible for production, but breaks reload in dev due to a race condition with loading config.json