### PR TITLE
Fix broken state due to undefined variable

### DIFF
--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -406,13 +406,13 @@ class CloudDeployProgress extends BaseWizardPage {
   render() {
     // choose between site or site with wipedisks (dayzero-site)
     let sitePlaybook = 'site';
-    if (this.props.deployConfig['wipeDisks']) {
-      sitePlaybook = 'dayzero-site';
-    }
 
     // Build the payload from the deployment configuration page options
     let payload = {};
     if (this.props.deployConfig) {
+      if (this.props.deployConfig['wipeDisks']) {
+        sitePlaybook = 'dayzero-site';
+      }
       payload['verbose'] = this.props.deployConfig['verbosity'];
       payload['extraVars'] = {};
       // don't prompt "Are you sure?" questions for wipedisks


### PR DESCRIPTION
Deployment page is broken when a new tab is opened.  This should fix it