### PR TITLE
SCRD-1895 Fix save function on Add Server Manually modal

### DIFF
--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -390,8 +390,8 @@ class AssignServerRoles extends BaseWizardPage {
   }
 
   renderAddServerManuallyModal = () => {
-    const serverGroups = getServerGroups(this.props.model);
-    const nicMappings = getNicMappings(this.props.model);
+    const serverGroups = getServerGroups(this.props.model).toJS();
+    const nicMappings = getNicMappings(this.props.model).toJS();
     let roles = getServerRoles(this.props.model).map(e => e['serverRole']);
     roles.unshift('');
     if (!this.newServer.role) {

--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -390,8 +390,8 @@ class AssignServerRoles extends BaseWizardPage {
   }
 
   renderAddServerManuallyModal = () => {
-    const serverGroups = getServerGroups(this.props.model).toJS();
-    const nicMappings = getNicMappings(this.props.model).toJS();
+    const serverGroups = getServerGroups(this.props.model);
+    const nicMappings = getNicMappings(this.props.model);
     let roles = getServerRoles(this.props.model).map(e => e['serverRole']);
     roles.unshift('');
     if (!this.newServer.role) {

--- a/src/utils/ModelUtils.js
+++ b/src/utils/ModelUtils.js
@@ -35,14 +35,14 @@ export function isRoleAssignmentValid (role, checkInputs) {
 export function getServerGroups(model) {
   let groups = model.getIn(['inputModel','server-groups'])
     .sort((a,b) => alphabetically(a.get('name'), b.get('name')))
-    .map(group => group.get('name'));
+    .map(group => group.get('name')).toJS();
   return groups;
 }
 
 export function getNicMappings(model) {
   return model.getIn(['inputModel','nic-mappings'])
     .sort((a,b) => alphabetically(a.get('name'), b.get('name')))
-    .map(nic => nic.get('name'));
+    .map(nic => nic.get('name')).toJS();
 }
 
 function getCleanedServer(srv) {


### PR DESCRIPTION
The server group and NIC mapping fields in the Add Server Manually modal did not save the default values correctly. This was because the getServerGroups and getNicMappings functions used to return a list of name strings but was refactored to return a list of objects, which caused the setting of initial
values for server group and NIC mapping fields to invalid values.