### PR TITLE
Use common functions for interacting with shim

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -15,12 +15,11 @@
 import React, { Component } from 'react';
 import './Deployer.css';
 import { translate } from './localization/localize.js';
-import { getAppConfig } from './utils/ConfigHelper.js';
 import { STATUS } from './utils/constants.js';
 import WizardProgress from './components/WizardProgress';
 import { LoadingMask } from './components/LoadingMask.js';
 import { Map, fromJS } from 'immutable';
-import { fetchJson, postJson } from './utils/RestUtils.js';
+import { fetchJson, postJson, deleteJson } from './utils/RestUtils.js';
 
 
 
@@ -101,9 +100,7 @@ class InstallWizard extends Component {
         }})
       .then(() => {
         if (forcedReset) {
-          return fetch(getAppConfig('shimurl') + '/api/v1/server?source=sm,ov,manual', {
-            method: 'DELETE'
-          });
+          return deleteJson('/api/v1/server?source=sm,ov,manual');
         }
       })
       .catch((error) => {

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -169,7 +169,7 @@
     "server.test.sm.error.hostport": "Testing connection to SUSE Manager failed. {0} is not found.",
     "server.test.sm.error.userpass": "Testing connection to SUSE Manager {0} failed for user {1}.",
     "server.test.sm.error": "Testing connection for SUSE Manager {0}.",
-    "server.test.sm.error.secured": "Testing connection to SUSE Manager {0} failed. Have a certificate error.",
+    "server.test.sm.error.secured": "Testing connection to SUSE Manager {0} failed with a certificate error.",
     "server.discover.sm.error": "Failed to get SUSE Manager servers.",
     "server.discover.ov.error": "Failed to get HPE Oneview servers.",
     "server.discover.save.error": "Failed to save discovered servers",

--- a/src/utils/ConfigHelper.js
+++ b/src/utils/ConfigHelper.js
@@ -14,18 +14,38 @@
 **/
 var appConfigs = {
   'shimurl': window.location.protocol + '//' + window.location.hostname + ':' + 8081,
-  //remove this when release
-  'dev': true
 };
 
 // check for a config file, if present, overwrite the defaults
-fetch('config.json')
-  .then(response => response.json())
-  .then((responseData) =>
-  {
-    Object.assign(appConfigs, responseData);
-  });
+function loadConfig() {
+  return fetch('config.json')
+    .then(response => response.json())
+    .then((responseData) =>
+    {
+      return Object.assign(appConfigs, responseData);
+    });
+}
 
+// IMPORTANT:
+//   This function accesses appConfigs, which is populated
+// asynchronously.  This function will introduce a race condition
+// if called before that function has completed.
 export function getAppConfig(key) {
   return appConfigs[key];
 }
+
+
+var cfgPromise;
+
+// Return a promise whose value is the key being requested.  When
+// called the first time, there will be a slight delay in order to
+// actually load the config file, which in turn is done by loadConfig
+// in a promise.  Subsequent calls to this function will not trigger
+// re-loading the file since we are storing and reusing the result
+// of the loadConfig promise.
+//
+export function getConfig(key) {
+  cfgPromise = cfgPromise || loadConfig();
+  return cfgPromise.then(cfg => cfg[key]);
+}
+

--- a/src/utils/RestUtils.js
+++ b/src/utils/RestUtils.js
@@ -12,7 +12,50 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 **/
-import { getAppConfig } from './ConfigHelper.js';
+import { getConfig } from './ConfigHelper.js';
+
+// Merge init objects together.  Any nested 'headers' objects will also be merged
+function mergeInits(...inits) {
+  let mergedHeaders = {};
+
+  // Combine headers together
+  for (let init of inits) {
+    if (init.headers) {
+      Object.assign(mergedHeaders, init.headers);
+    }
+  }
+
+  return Object.assign({}, ...inits, {'headers': mergedHeaders});
+}
+
+function doJson(url, method, body, init) {
+
+  let myInit = {
+    method: method,
+    headers: {
+      'Accept': 'application/json, text/plain, */*',
+      'Content-Type': 'application/json'
+    }
+  };
+
+  if (init) {
+    myInit = mergeInits(myInit, init);
+  }
+
+  if (! ('body' in myInit)) {
+    if (body === undefined && (method === 'POST' || method === 'PUT')) {
+      myInit.body = JSON.stringify('');
+    } else if (typeof(body) === 'string') {
+      myInit.body = body;
+    } else {
+      myInit.body = JSON.stringify(body);
+    }
+  }
+
+  return buildUrl(url)
+    .then(url => fetch(url, myInit))
+    .then(res => extractResponse(res));
+}
 
 /**
  * Perform a fetch from a REST endpoint, convert the fetched JSON into a Javascript object, and return
@@ -24,33 +67,13 @@ import { getAppConfig } from './ConfigHelper.js';
  *                       will contain HTTP headers when supplied.
  */
 export function fetchJson(url, init) {
-
-  const myUrl = buildUrl(url);
-
-  let myInit = {
-    method: 'GET',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json',
-    }
-  };
-
-  if (init) {
-    myInit = Object.assign(myInit, init);
-  }
-
-  return fetch(myUrl, myInit)
-    .then(res => {
-      if (res.ok) {
-        return res.json();
-      } else {
-        return Promise.reject(res.statusText);
-      }
-    });
+  return doJson(url, 'GET', undefined, init);
 }
 
+
+
 /**
- * Perform a post from a REST endpoint, converting the passed body to JSON, and return the result
+ * Perform a post to a REST endpoint, converting the passed body to JSON, and return the result
  * as a promise
  *
  * @param {String} url - URL or partial URL (one without the leading http).  If a partial URL
@@ -61,47 +84,96 @@ export function fetchJson(url, init) {
  *                        will contain HTTP headers when supplied.
  */
 export function postJson(url, body, init) {
+  return doJson(url, 'POST', body, init);
+}
 
-  const myUrl = buildUrl(url);
 
-  let myInit = {
-    method: 'POST',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    }
-  };
-  if (init) {
-    myInit = Object.assign(myInit, init);
-  }
+/**
+ * Perform a put from a REST endpoint, converting the passed body to JSON, and return the result
+ * as a promise
+ *
+ * @param {String} url - URL or partial URL (one without the leading http).  If a partial URL
+ *                       is received the request will be directed to the "shim".
+ * @param {Object} body - Javascript object that will be converted to Json and posted to the URL.  If body
+ *                        is undefined, then an empty string will be POSTed
+ * @param {Object} init - optional argument that will be passed to the fetch() function.  It often
+ *                        will contain HTTP headers when supplied.
+ */
+export function putJson(url, body, init) {
+  return doJson(url, 'PUT', body, init);
+}
 
-  if (! ('body' in myInit)) {
-    if (body === undefined) {
-      myInit.body = '';
-    } else if (typeof(body) === 'string') {
-      myInit.body = body;
-    } else {
-      myInit.body = JSON.stringify(body);
-    }
-  }
+/**
+ * Perform a delete from a REST endpoint, and return a promise
+ *
+ * @param {String} url - URL or partial URL (one without the leading http).  If a partial URL
+ *                       is received the request will be directed to the "shim".
+ */
+export function deleteJson(url) {
+  return doJson(url, 'DELETE');
+}
 
-  return fetch(myUrl, myInit)
-    .then(res => {
-      if (res.ok) {
-        return Promise.resolve('Success');
+/**
+ * Common error-checking function that returns a promise the yields the json
+ * text of the response (when valid) or returns rejected Promise with the text of the
+ * error message
+ */
+function extractResponse(response) {
+
+  return response.text()
+    .then(txt => {
+
+      // Attempt to extract the text (and convert from JSON) if possible, even
+      // if the response was an error, in order to provide that information back to
+      // the caller
+      let value;
+
+      try {
+        // JSON.parse is used here instead of response.json because sometimes
+        // the return value is just text, and it makes the promise chain handling
+        // overly convoluted to try to use response.json sometimes and response.txt
+        // when that fails, while at the same time propagating exceptions up when
+        // the ardana service reports an error.
+        value = JSON.parse(txt);
+      } catch (SyntaxError) {
+        // Unable to convert to json, returning text
+        value = txt;
+      }
+
+      if (response.ok) {
+        return value;
       } else {
-        return Promise.reject(res.statusText);
+        return Promise.reject(new RestError(response.statusText, response.status, value));
       }
     });
 }
 
-function buildUrl(url) {
 
-  if (url.startsWith('http')) {
-    return url;
+/**
+ * Return a promise that returns the full URL (a promise is used because
+ * the information needed to build the URL comes from an asynchonous function)
+ */
+export function buildUrl(url) {
+
+  return getConfig('shimurl').
+    then(val => {
+      if (url.startsWith('http')) {
+        return url;
+      } else {
+        // prepend the shimurl if we receive a URL without a scheme.  Note that the incoming
+        // url may contain a leading / but is not required to.
+        return val + '/' + url.replace(/^\//, '');
+      }
+    });
+}
+
+/**
+ * Use a custom Error for representing errors from these json functions
+ */
+class RestError extends Error {
+  constructor(message, status, value) {
+    super(message);
+    this.status = status;
+    this.value = value;
   }
-
-  // prepend the shimurl if we receive a URL without a scheme.  Note that the incoming
-  // url may contain a leading / but is not required to.
-  return getAppConfig('shimurl') + '/' + url.replace(/^\//, '');
 }


### PR DESCRIPTION
Use a common set of functions for making REST fetch, post, and delete
calls to the shim.  Several advantages of this approach are:
- handle a known race condition where the UI needs to retrieve the URL
  to the shim (in an asyncronous function that fetches the config file)
  and to use the shim URL (in any asyncronous function that interacts
  with the shim).  The common functions use a chain of promises to
  eliminate this race condition.
- unify REST response handling, including extraction and conversion of
  results and error responses
- simplify and unify REST request headers so that a common, well-known
  set are used