### PR TITLE
SCRD-1710 remove green arrow from Networks tab

### DIFF
--- a/src/pages/ServerRoleSummary.js
+++ b/src/pages/ServerRoleSummary.js
@@ -19,7 +19,7 @@ import CollapsibleTable from './ServerRoleSummary/CollapsibleTable.js';
 import { ActionButton } from '../components/Buttons.js';
 import { EditCloudSettings } from './ServerRoleSummary/EditCloudSettings.js';
 import { getServerRoles, isRoleAssignmentValid, updateServersInModel } from '../utils/ModelUtils.js';
-import { MODEL_SERVER_PROPS_ALL } from "../utils/constants.js";
+import { MODEL_SERVER_PROPS_ALL } from '../utils/constants.js';
 
 class ServerRoleSummary extends BaseWizardPage {
 

--- a/src/pages/ServerRoleSummary/NetworksTab.js
+++ b/src/pages/ServerRoleSummary/NetworksTab.js
@@ -79,11 +79,7 @@ class NetworksTab extends Component {
       <tr key='networkAction' className='action-row'>
         <td><i className={addClass} onClick={this.handleAddNetwork}>add_circle</i>
           {translate('add.network')}</td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
-        <td></td>
+        <td colSpan="5"/>
       </tr>
     );
   }

--- a/src/pages/ServerRoleSummary/NetworksTab.js
+++ b/src/pages/ServerRoleSummary/NetworksTab.js
@@ -75,15 +75,16 @@ class NetworksTab extends Component {
   renderActionRow() {
     let addClass = 'material-icons add-button';
     addClass = this.state.mode !== MODE.NONE ? addClass + ' disabled' : addClass;
-    let bottomClass = 'bottom-action-row';
-    bottomClass = this.state.mode === MODE.ADD ? bottomClass + ' on' : bottomClass;
     return (
-      <div className='bottom-action-container'>
-        <div key='networkAction' className={bottomClass}>
-          <span><i className={addClass} onClick={() => this.handleAddNetwork()}>add_circle</i>
-            {translate('add.network')}</span>
-        </div>
-      </div>
+      <tr key='networkAction' className='action-row'>
+        <td><i className={addClass} onClick={this.handleAddNetwork}>add_circle</i>
+          {translate('add.network')}</td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+        <td></td>
+      </tr>
     );
   }
 
@@ -104,8 +105,7 @@ class NetworksTab extends Component {
   }
 
   renderNetworkTable() {
-    let trueStr = translate('true');
-    let falseStr = translate('false');
+    const checkMark = <i className='material-icons data-icon'>check</i>;
     let editClass = 'glyphicon glyphicon-pencil edit-button';
     let removeClass = 'glyphicon glyphicon-trash remove-button';
     if (this.state.mode !== MODE.NONE) {
@@ -123,7 +123,7 @@ class NetworksTab extends Component {
             <td>{network.get('cidr')}</td>
             <td>{network.get('gateway-ip')}</td>
             <td>{network.get('network-group')}</td>
-            <td>{network.get('tagged-vlan') ? trueStr : falseStr}</td>
+            <td>{network.get('tagged-vlan') ? checkMark : ''}</td>
             <td>
               <div className='row-action-container'>
                 <span onClick={() => this.handleEditNetwork(network)} className={editClass} />
@@ -151,7 +151,10 @@ class NetworksTab extends Component {
               <th></th>
             </tr>
           </thead>
-          <tbody>{rows}</tbody>
+          <tbody>
+            {rows}
+            {this.renderActionRow()}
+          </tbody>
         </table>
       </div>
     );
@@ -164,7 +167,6 @@ class NetworksTab extends Component {
           {this.renderNetworkTable()}
           {this.state.mode !== MODE.NONE && this.renderUpdateNetworkSection()}
         </div>
-        {this.renderActionRow()}
         {this.renderRemoveConfirmation()}
       </div>
     );

--- a/src/pages/ValidateConfigFiles.js
+++ b/src/pages/ValidateConfigFiles.js
@@ -412,7 +412,7 @@ class ConfigPage extends BaseWizardPage {
             </Tab>
           </Tabs>
         </div>
-        {this.state.showNavButtons ? this.renderNavButtons() : ''};
+        {this.state.showNavButtons ? this.renderNavButtons() : ''}
       </div>
     );
   }

--- a/src/styles/pages/ServerRoleSummary.less
+++ b/src/styles/pages/ServerRoleSummary.less
@@ -147,6 +147,12 @@
     }
   }
 
+  .data-icon {
+    color: @page-font-color;
+    font-size: 1.2em;
+    margin-left: 0.2em;
+  }
+
   .bottom-action-container{
     width: 100%;
     display: inline-flex;


### PR DESCRIPTION
Most items in this story were already taken care of by previous changes. This change only removes the green arrow at Add Network action on Networks tab, in order to be consistent with the behavior on other tabs. The green arrow implementation could be resurrected later on with SCRD-1996.

Also includes the following miscellaneous changes:
- fix lint complaint in ServerRoleSummary.js
- remove extra ';' on Review Configuration Files page
- use check marks in the Tagged VLAN column of the Networks tab, instead of the word "True" or 'False'