### PR TITLE
Reload model after editing model files

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -156,8 +156,9 @@ class InstallWizard extends Component {
     //Pass the update function as a property
     props.updateGlobalState = this.updateGlobalState;
 
-    //Pass a function to force a model save
+    //Pass functions to force a model save and reload
     props.saveModel = this.saveModel;
+    props.loadModel = this.loadModel;
 
     return React.createElement(this.props.pages[this.state.currentStep].component, props);
   }
@@ -285,6 +286,17 @@ class InstallWizard extends Component {
       return updatedState;
     }, mycallback);
   }
+
+  // Pages within the installer may request that the model be forceably loaded
+  // from disk, espcially when a change is made to directly to the model files
+  // to the model.  Returns a promise
+  loadModel = () => fetchJson('/api/v1/clm/model')
+    .then(responseData => {
+      this.setState({'model': fromJS(responseData)});
+    })
+    .catch((error) => {
+      console.log('Unable to retrieve saved model');// eslint-disable-line no-console
+    })
 
   // Pages within the installer may request that the model be saved to disk,
   // which is especially important when some significant change has been made

--- a/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
+++ b/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
@@ -18,6 +18,7 @@ import { ActionButton } from '../../components/Buttons.js';
 import { alphabetically } from '../../utils/Sort.js';
 import { fetchJson, postJson } from '../../utils/RestUtils.js';
 import { ErrorMessage } from '../../components/Messages.js';
+import { ServerInput } from '../../components/ServerUtils.js';
 
 class EditTemplateFile extends Component {
   constructor(props) {
@@ -39,7 +40,7 @@ class EditTemplateFile extends Component {
     this.props.closeAction(this.props.editFile);
   }
 
-  handleChange(event) {
+  handleChange = (event) => {
     this.setState({contents: event.target.value});
   }
 
@@ -49,11 +50,13 @@ class EditTemplateFile extends Component {
 
   render() {
     return (
-      <div className='edit-container'>
-        <div>
-          <textarea name='fileContents' className='service-file-editor rounded-corner' wrap='off'
-            value={this.state.contents} onChange={(e) => this.handleChange(e)}/>
-        </div>
+      <div className='edit-container file-editor'>
+        <ServerInput
+          inputValue={this.state.contents}
+          inputName='fileContents'
+          inputType='textarea'
+          inputAction={this.handleChange}
+        />
         <div className='button-container btn-row'>
           <ActionButton type='default'
             displayLabel={translate('cancel')}
@@ -158,7 +161,7 @@ class ServiceTemplatesTab extends Component {
       );
     }
     else {
-      return (<div className='col-xs-8'>{translate(('validate.config.service.info'))}</div>);
+      return (<div className='col-xs-6'>{translate(('validate.config.service.info'))}</div>);
     }
   }
 
@@ -210,7 +213,7 @@ class ServiceTemplatesTab extends Component {
       });
 
     return (
-      <div className='col-xs-4 verticalLine'>
+      <div className='col-xs-6 verticalLine'>
         <ul className='all-service-list'>{serviceList}</ul>
       </div>
     );
@@ -219,7 +222,7 @@ class ServiceTemplatesTab extends Component {
   render() {
     return (
       <div className='template-service-files'>
-        <div className='body'>
+        <div>
           {!this.state.editFile && this.renderServiceList()}
           {this.renderFileSection()}
         </div>

--- a/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
+++ b/src/pages/ValidateConfigFiles/ServiceTemplatesTab.js
@@ -57,7 +57,7 @@ class EditTemplateFile extends Component {
           inputType='textarea'
           inputAction={this.handleChange}
         />
-        <div className='button-container btn-row'>
+        <div className='btn-row'>
           <ActionButton type='default'
             displayLabel={translate('cancel')}
             clickAction={() => this.handleCancel()}/>
@@ -180,9 +180,9 @@ class ServiceTemplatesTab extends Component {
       return (
         <li key={index}>
           <span className='service-heading'>
-            <i className='material-icons folder'
+            <i className='material-icons'
               onClick={() => this.handleToggleService(item)}>keyboard_arrow_down</i>
-            <h4>{item.service}</h4></span>
+            {item.service}</span>
           <ul className='file-list'>{fileList}</ul>
         </li>
       );
@@ -191,9 +191,9 @@ class ServiceTemplatesTab extends Component {
       return (
         <li key={index}>
           <span className='service-heading'>
-            <i className='material-icons folder'
+            <i className='material-icons'
               onClick={() => this.handleToggleService(item)}>keyboard_arrow_right</i>
-            <h4>{item.service}</h4></span>
+            {item.service}</span>
         </li>
       );
     }

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -181,3 +181,16 @@ p {
 .modal-backdrop {
   z-index: 1050;
 }
+
+.file-editor textarea {
+
+  font-family: monospace;
+  font-size: 14px;
+  min-height: 35em;
+  width: 100%;
+  margin-bottom: 1em;
+
+  white-space: pre;
+  overflow-wrap: normal;
+  overflow-x: scroll;
+}

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -37,13 +37,6 @@
   }
 }
 
-.config-file-editor {
-  font-family: monospace;
-  min-height: 40em;
-  min-width: 40em;
-  margin-bottom: 1em;
-}
-
 .config-form {
   max-width: 31em;
   margin-left: 4em;
@@ -90,36 +83,29 @@
   background: transparent;
 }
 
+/*
 .template-service-files {
+*/
+
+.all-service-list {
+
+  list-style-type: none;
   font-size: 1.1em;
 
-  .edit-container {
-    .button-container {
-      margin-top: 1em;
-    }
-  }
-
-  ul.all-service-list {
-    list-style-type: none;
-    line-height: 1.5em;
-    min-height: 35em;
-    max-height: 40em;
-    overflow: auto;
-  }
-
-  ul.file-list {
+  ul {
     list-style-type: none;
     line-height: 1.5em;
   }
 
-  .material-icons.folder {
-    line-height: 1.5em;
-    margin-right: 0.5em;
+  .material-icons {
     cursor: pointer;
+    font-size: 1.5em;
+    line-height: inherit;
   }
 
-  li span.service-heading {
+  .service-heading {
     display: inline-flex;
+    line-height: 1.5em;
   }
 }
 

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -94,15 +94,8 @@
   font-size: 1.1em;
 
   .edit-container {
-    width: 50%;
     .button-container {
       margin-top: 1em;
-    }
-    .service-file-editor {
-      font-family: monospace;
-      min-height: 35em;
-      width: 100%;
-      margin-bottom: 1em;
     }
   }
 
@@ -117,11 +110,6 @@
   ul.file-list {
     list-style-type: none;
     line-height: 1.5em;
-  }
-
-  .body {
-    display: inline-block;
-    width: 100%;
   }
 
   .material-icons.folder {

--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -83,14 +83,11 @@
   background: transparent;
 }
 
-/*
-.template-service-files {
-*/
-
 .all-service-list {
 
   list-style-type: none;
   font-size: 1.1em;
+  min-height: 35em;
 
   ul {
     list-style-type: none;


### PR DESCRIPTION
When model files are edited directly in the validate config page, the
model should be reloaded from disk so that if a user goes back to a
previous page, those direct edits are reflected in the UI.

To help alleviate the problem of saving an improperly formatted yaml
file and failing to reload it, the textarea uses a yaml validator to
detect invalid yaml and avoid saving.

To improve code re-use, both file editors on this page (one on the Model
tab and the other on the Templates and Services tag) now use the
ServerInput component and use common styling for the editor and page
layout.