### PR TITLE
Improve scrolling when all template sections are expanded

### DIFF
--- a/src/styles/components/ymlvalidator.less
+++ b/src/styles/components/ymlvalidator.less
@@ -88,6 +88,8 @@
   list-style-type: none;
   font-size: 1.1em;
   min-height: 35em;
+  max-height: 40em;
+  overflow: auto;
 
   ul {
     list-style-type: none;


### PR DESCRIPTION
When all sections under the "Templates and Services" tab of the config
file validation screen are expanded, the scroll bar is now on the list
of templates instead of at the far right of the screen, which prevents
the tab list from scrolling off the screen.