### PR TITLE
Removed the secure restriction for setting session key option

### DIFF
--- a/src/pages/AssignServerRoles.js
+++ b/src/pages/AssignServerRoles.js
@@ -495,11 +495,8 @@ class AssignServerRoles extends BaseWizardPage {
     let expTime = new Date(now);
     expTime.setMinutes(now.getMinutes() + minutes);
 
-    let retOp = {path: '/', expires: expTime, secure: true, sameSite: true};
-    //allow http for development
-    if(getAppConfig('dev')) {
-      retOp.secure = false;
-    }
+    // if later decide to always run installer with https, add secure: true
+    let retOp = {path: '/', expires: expTime, sameSite: true};
     return retOp;
   }
 


### PR DESCRIPTION
When save session key we set secure:true assume we always run installer with https. If run installer with http, it depends on dev in the default.cfg to be true to make secure: false.  If run with http and option secure: true, it can cause some browser doesn't set session key at all even within the same session. This checkin removes that restriction for now. Added note to revisit if we decide we always want to run installer with https. 