### PR TITLE
Fix descriptions on Cloud Model Summary

### DIFF
--- a/src/components/ServerUtils.js
+++ b/src/components/ServerUtils.js
@@ -94,28 +94,19 @@ export class ServerRolesAccordion extends Component {
   renderSections() {
     let sections = this.props.serverRoles.map((role, idx) => {
       let optionDisplay = '';
-      if(role.minCount === 0) {
+      if(role.minCount !== undefined) {
         optionDisplay =
           translate(
-            'add.server.role.no.min.display',
-            role.name, role.serverRole, role.servers.length
+            'add.server.role.min.count.display',
+            role.name, role.serverRole, role.servers.length, role.minCount
           );
       }
       else {
-        if(role.minCount !== undefined) {
-          optionDisplay =
-            translate(
-              'add.server.role.min.count.display',
-              role.name, role.serverRole, role.servers.length, role.minCount
-            );
-        }
-        else {
-          optionDisplay =
-            translate(
-              'add.server.role.member.count.display',
-              role.name, role.serverRole, role.servers.length, role.memberCount
-            );
-        }
+        optionDisplay =
+          translate(
+            'add.server.role.member.count.display',
+            role.name, role.serverRole, role.servers.length, role.memberCount
+          );
       }
       let isOpen = (idx === this.state.accordionPosition);
       let valid = isRoleAssignmentValid(role);

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -58,7 +58,8 @@
     "model.summary.heading": "Cloud Model to Deploy: {0}",
     "model.summary.mandatory": "Mandatory Components",
     "model.summary.additional": "Additional Components",
-    "model.summary.edit.machines": "Edit number of machines",
+    "model.summary.edit.nodes": "Edit number of nodes",
+    "model.summary.edit.min.nodes": "Edit minimum number of nodes",
 
     "validate.config.files.heading": "Review Configuration Files",
     "validate.config.files.validate": "Validate",

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -136,7 +136,7 @@ class CloudModelSummary extends BaseWizardPage {
     return filtered.map((item, key) => {
 
       var count_type = item.has('member-count') ? 'member-count' : 'min-count';
-      var value = item.get(count_type);
+      var value = count_type === 'min-count' ? '>= ' + item.get(count_type) : item.get(count_type);
 
       // Build the id, which will be used as the activeItem
       var id = [section, key, count_type].join('.');
@@ -158,6 +158,10 @@ class CloudModelSummary extends BaseWizardPage {
     var mandatoryItems = this.state.controlPlane ? this.renderItems('clusters') : [];
     var additionalItems = this.state.controlPlane ? this.renderItems('resources') : [];
     var number = this.state.activeItem ? this.state.controlPlane.getIn(this.getKey()) : 0;
+    let editNodesLabel = translate('model.summary.edit.nodes');
+    if (this.state.activeItem && this.state.activeItem.indexOf('min-count') !== -1) {
+      editNodesLabel = translate('model.summary.edit.min.nodes');
+    }
     var additionalLabel = (additionalItems.size > 0) ?
       <div><h4>{translate('model.summary.additional')}</h4></div> : <div/>;
 
@@ -182,7 +186,7 @@ class CloudModelSummary extends BaseWizardPage {
             <p />
             {this.state.activeItem
               ? <div className='margin-top-80'>
-                <h4>{translate('model.summary.edit.machines')}</h4>
+                <h4>{editNodesLabel}</h4>
                 <form className='form-inline'>
                   <div className='form-group'>
                     <input type='number'


### PR DESCRIPTION
Fixes include:
- Cloud Model Summary page
      * add '>=' in front of number of nodes in the card if the number is from the 'min-count' field
      * update 'Edit number of machines' to 'Edit number of nodes' if the number is from the 'member-
        count' field and to 'Edit minimum number of nodes' if the number is from the 'min-count' field
- Assign Server Roles
      * always display 'Min Size: x' in the collapsible table header (used to not display when the count is 0) 
