### PR TITLE
Remove pencil icon from Cloud Model Summary

### DIFF
--- a/src/components/Buttons.js
+++ b/src/components/Buttons.js
@@ -153,7 +153,6 @@ class ActivePickerButton extends Component {
           className='card rounded-corner shadowed-border'
           onClick={this.handleClick}
           value={this.props.value} >
-          <p className='glyphicon glyphicon-pencil edit-icon pull-right'></p>
           <p className='card-text-unit' id={this.props.id}>
             {this.props.value}
           </p>

--- a/src/pages/CloudModelSummary.js
+++ b/src/pages/CloudModelSummary.js
@@ -167,7 +167,7 @@ class CloudModelSummary extends BaseWizardPage {
           {this.renderHeading(translate('model.summary.heading', this.props.model.get('name')))}
         </div>
         <div className='wizard-content'>
-          <div className='picker-container altwidth1'>
+          <div className='picker-container'>
             <h4>{translate('model.summary.mandatory')}</h4>
             <div className='section'>
               {mandatoryItems}
@@ -177,7 +177,7 @@ class CloudModelSummary extends BaseWizardPage {
               {additionalItems}
             </div>
           </div>
-          <div className='details-container altwidth1'>
+          <div className='details-container'>
             {this.getDescription()}
             <p />
             {this.state.activeItem

--- a/src/styles/common.less
+++ b/src/styles/common.less
@@ -49,10 +49,6 @@ p {
   margin-bottom: 1em;
 }
 
-.edit-icon {
-  font-size: 1em;
-}
-
 .verticalLine {
   border-right: thin solid lightgray;
 }

--- a/src/styles/components/modelpicker.less
+++ b/src/styles/components/modelpicker.less
@@ -25,9 +25,6 @@
     width: 100%;
     display: inline-block;
   }
-  &.altwidth1{
-    width: 60%;
-  }
 }
 
 .details-container {
@@ -38,9 +35,6 @@
   max-height: 40em;
   overflow: auto;
   vertical-align: top;
-  &.altwidth1{
-    width: 40%;
-  }
 }
 
 .model-details > ul, ol {


### PR DESCRIPTION
Remove the pencil icon from the Cloud Model Summary page and also adjust the proportion of the left/right sections from 60/40 to 50/50 to be consistent with other pages.