### PR TITLE
Be able to run  multiple playbooks

### DIFF
--- a/src/InstallWizard.js
+++ b/src/InstallWizard.js
@@ -50,18 +50,31 @@ class InstallWizard extends Component {
       //   like credentials for remote systems, and so on.  Information that is already stored
       //   in the model, such as its name or which servers are assigned to which roles, should
       //   not be duplicated here since it is already being persisted in the model
-      sitePlayId: undefined,  // play id of the deployment playbook
-      installPlayId: undefined,  // play id of the playbook to provision operating systems
+      // playbookStatus structure example is like
+      // [{
+      //  name: 'dayzero-os-provision', status: '', playId: ''
+      // }, {
+      //  name: 'dayzero-pre-deployment', status: '', playId: ''
+      // }, {
+      //  name: 'dayzero-site', status: '', playId: ''
+      // }]
+      //
+      playbookStatus: undefined,
+      commitStatus: undefined, // to make it simple, we only have one to commit
       model: Map(),           // immutable model
       connectionInfo: undefined, // config info for external discovery services
       deployConfig: undefined, // cloud deployment configuration
     };
 
+
     // Indicate which of the above state variables are passed to wizard pages and can be set by them
-    this.globalStateVars = ['sitePlayId', 'installPlayId', 'model', 'connectionInfo', 'deployConfig'];
+    this.globalStateVars = ['commitStatus', 'playbookStatus', 'model', 'connectionInfo', 'deployConfig'];
+
 
     // Indicate which of the state variables will be persisted to, and loaded from, the progress API
-    this.persistedStateVars = ['currentStep', 'steps', 'sitePlayId', 'installPlayId', 'connectionInfo'];
+    this.persistedStateVars = [
+      'currentStep', 'steps', 'commitStatus', 'playbookStatus', 'connectionInfo', 'deployConfig'
+    ];
 
     // Note: if no progress data can be found, responseData is an empty string
     const forcedReset = window.location.search.indexOf('reset=true') !== -1;

--- a/src/components/PlaybookProcess.js
+++ b/src/components/PlaybookProcess.js
@@ -23,6 +23,13 @@ import io from 'socket.io-client';
 import { List } from 'immutable';
 import debounce from 'lodash/debounce';
 
+const PROGRESS_UI_CLASS = {
+  NOT_STARTED: 'notstarted',
+  FAILED: 'fail',
+  COMPLETE: 'succeed',
+  IN_PROGRESS: 'progressing'
+};
+
 class LogViewer extends Component {
 
   constructor(props) {
@@ -82,12 +89,9 @@ class PlaybookProgress extends Component {
       playbooksStarted: [],          // list of playbooks that have started
       playbooksComplete: [],         // list of playbooks that have completed
       playbooksError: [],            // list of playbooks that have errored
-      commit: 'notstarted',          // keep track of the commit
-
-      displayedLogs: List()          // log messages to display in the log viewer
+      displayedLogs: List(),         // log messages to display in the log viewer,
+      commit: this.props.commitStatus // status to keep track of committing model
     };
-
-    this.startPlaybook();
   }
 
   getError() {
@@ -96,23 +100,45 @@ class PlaybookProgress extends Component {
         <pre className='log'>{this.state.errorMsg}</pre></div>);
   }
 
+  getStatusCSSClass = (status) => {
+    let retClass = '';
+    switch (status) {
+    case  STATUS.IN_PROGRESS:
+      retClass = PROGRESS_UI_CLASS.IN_PROGRESS;
+      break;
+    case STATUS.COMPLETE:
+      retClass = PROGRESS_UI_CLASS.COMPLETE;
+      break;
+    case STATUS.FAILED:
+      retClass = PROGRESS_UI_CLASS.FAILED;
+      break;
+    default:
+      retClass = PROGRESS_UI_CLASS.NOT_STARTED;
+      break;
+    }
+    return retClass;
+  }
+
   getCommitStatus() {
-    return (<li key='commit' className={this.state.commit}>{translate('deploy.progress.commit')}</li>);
+    if(this.state.commit !== undefined) {
+      const stClass = this.getStatusCSSClass(this.state.commit);
+      return (<li key='commit' className={stClass}>{translate('deploy.progress.commit')}</li>);
+    }
   }
 
   getProgress() {
-    return this.props.steps.map((step, index) => {
-      var status = 'notstarted', i = 0;
+    let progresses =  this.props.steps.map((step, index) => {
+      let status = STATUS.NOT_STARTED, i = 0;
 
       //for each step, check if any playbooks failed
-      for(i = 0; i < step.playbooks.length; i++) {
+      for (i = 0; i < step.playbooks.length; i++) {
         if (this.state.playbooksError.indexOf(step.playbooks[i]) !== -1) {
-          status = 'fail';//theres at least 1 ERROR playbook
+          status = STATUS.FAILED ;//there is at least 1 ERROR playbook
         }
       }
 
       //check if all playbooks have finished
-      if(status === 'notstarted') {
+      if (status === STATUS.NOT_STARTED) {
         let complete = true;
         for (i = 0; i < step.playbooks.length; i++) {
           if(this.state.playbooksComplete.indexOf(step.playbooks[i]) === -1) {
@@ -122,51 +148,199 @@ class PlaybookProgress extends Component {
         }
 
         //if all playbooks were complete, set the status to succeed
-        if(complete) {
-          status = 'succeed';
+        if (complete) {
+          status = STATUS.COMPLETE;
         }
       }
 
-      //if the status has not previously been set to fail or complete,
+      // if the status has not previously been set to fail or complete,
       // check if any of the playbooks have started
-      if(status === 'notstarted') {
+      if (status === STATUS.NOT_STARTED) {
         //for each step, check if all needed playbooks are done
         //if any are not done, check if at least 1 has started
         for (i = 0; i < step.playbooks.length; i++) {
           if (this.state.playbooksStarted.indexOf(step.playbooks[i]) !== -1) {
-            status = 'progressing';
+            status = STATUS.IN_PROGRESS;
             break;//theres at least 1 started playbook
           }
         }
       }
 
-      return (<li key={index} className={status}>{step.label}</li>);
+      const statusClass = this.getStatusCSSClass(status);
+      return (<li key={index} className={statusClass}>{step.label}</li>);
     });
+
+    return progresses;
   }
 
-  monitorSocket = (playId) => {
+  monitorSocket = (playbookName, playId) => {
     // Note that this function is only called after a fetch has completed, and thus
     // the application config has already completed loading, so getAppConfig can
     // be safely used here
     this.socket = io(getAppConfig('shimurl'));
     this.socket.on('playbook-start', this.playbookStarted);
-    this.socket.on('playbook-stop', this.playbookStopped);
-    this.socket.on('playbook-error', this.playbookError);
+    this.socket.on(
+      'playbook-stop',
+      (stepPlaybook) => { this.playbookStopped(stepPlaybook, playbookName, playId); });
+    this.socket.on(
+      'playbook-error',
+      (stepPlaybook) => { this.playbookError(stepPlaybook, playbookName, playId); });
     this.socket.on('log', this.logMessage);
-    this.socket.on('end', () => { this.socket.disconnect(); });
+    this.socket.on(
+      'end',
+      () => { this.processEndMonitorPlaybook(playbookName); });
     this.socket.emit('join', playId);
   }
 
-  startPlaybook = () => {
-    // Start the playbook if it has not already been done.  overallStatus will be set
-    // initially here.  If the playbook is launched, further updates to the status will
-    // be performed as playbook events arrive from the ardana service (which originate
-    // in the ansible playbooks)
+  findNextPlaybook = (completedPlaybookNames) => {
+    let lastIndex = 0;
+    // find which playbook is the last completed
+    completedPlaybookNames.forEach((plyName) => {
+      let theIndex = this.props.playbooks.findIndex((pName) => {
+        return plyName === pName;
+      });
+      if (theIndex >= lastIndex) {
+        lastIndex = theIndex;
+      }
+    });
 
-    if (this.props.playId) {
-      // Get the output of the play that has already been launched
+    if (lastIndex + 1 < this.props.playbooks.length) {
+      //return next playbook name
+      return this.props.playbooks[lastIndex + 1];
+    }
+    //done, no more next playbook
+    return;
+  }
 
-      fetchJson('/api/v1/clm/plays/' + this.props.playId, {
+  processEndMonitorPlaybook = (playbookName) => {
+    this.socket.disconnect();
+    const thisPlaybook = this.globalPlaybookStatus.find(e => e.name === playbookName);
+    // the global playbookStatus should be updated in playbookError or playbookStopped
+    if(thisPlaybook && thisPlaybook.status === STATUS.COMPLETE) {
+      let nextPlaybookName = this.findNextPlaybook([thisPlaybook.name]);
+      if (nextPlaybookName) {
+        this.launchPlaybook(nextPlaybookName);
+      }
+      else {
+        this.props.updatePageStatus(STATUS.COMPLETE); //set the caller page status
+      }
+    }
+  }
+
+  updateGlobalPlaybookStatus = (playbookName, playId, status) => {
+    const playbook = this.globalPlaybookStatus.find(e => e.name === playbookName);
+    if (playbook) {
+      if (playId && playId !== '') {
+        playbook.playId = playId;
+      }
+      playbook.status = status;
+      this.props.updateGlobalState('playbookStatus', this.globalPlaybookStatus);
+    }
+  }
+
+  // To get or initialize this.globalPlaybookStatus from the saved state
+  // playbookStatus
+  getGlobalPlaybookStatus = () => {
+    let retStatus = this.props.playbookStatus; //passed global in InstallWizards
+    // don't have playbookStatus, initialize it based on current playbooks
+    if (!retStatus) {
+      retStatus = this.props.playbooks.map((playbookName) => {
+        return {name: playbookName, status: undefined, playId: undefined};
+      });
+    }
+    else { // have playbook status
+      let exitStatus = retStatus.find((play) => this.props.playbooks.includes(play.name));
+      if (!exitStatus) {
+        //need init for this.props.playbooks
+        let initPlayStatus = this.props.playbooks.map((playbookName) => {
+          return {name: playbookName, status: undefined, playId: undefined};
+        });
+        retStatus = retStatus.concat(initPlayStatus);
+      }
+    }
+    return retStatus;
+  }
+
+  // summarize playbook processes status before processing
+  sumPlaybookProcessStatus = () => {
+    let retStatus = {in_progress: undefined, complete: [], failed: []};
+    this.globalPlaybookStatus.forEach((play) => {
+      if (this.props.playbooks.indexOf(play.name) !== -1) {
+        if (play.playId && play.status === STATUS.COMPLETE) {
+          retStatus.complete.push(play);
+        }
+        else if (play.playId && play.status === STATUS.IN_PROGRESS) {
+          //should be just one in progress
+          retStatus.in_progress = play;
+        }
+        else if (play.playId && play.status === STATUS.FAILED) {
+          retStatus.failed.push(play);
+        }
+      }
+    });
+    return retStatus;
+  }
+
+  commitChanges = () => {
+    const commitMessage = {'message': 'Committed via Ardana DayZero Installer'};
+    return postJson('/api/v1/clm/model/commit', commitMessage)
+      .then((response) => {
+        // update commit step status
+        this.setState({commit: STATUS.COMPLETE});
+        // update global commitStatus state
+        this.props.updateGlobalState('commitStatus', STATUS.COMPLETE);
+      })
+      .catch((error) => {
+        this.setState({errorMsg: translate('deploy.commit.failure', error.toString())});
+        // update commit step status
+        this.setState({commit: STATUS.FAILED});
+        // update global commitStatus state
+        this.props.updateGlobalState('commitStatus', STATUS.FAILED);
+        this.props.updatePageStatus(STATUS.FAILED);
+      });
+  }
+
+  processAlreadyDonePlaybook = (playbook) => {
+    // go get logs
+    fetchJson('/api/v1/clm/plays/' + playbook.playId + '/log')
+      .then(response => {
+        const message = response.trimRight('\n');
+        this.logsReceived = List(message);
+        this.setState((prevState) => {
+          return {displayedLogs: prevState.displayedLogs.concat(this.logsReceived)}; });
+      });
+
+    // update the UI status
+    fetchJson('/api/v1/clm/plays/' + playbook.playId + '/events')
+      .then(response => {
+        for (let evt of response) {
+          if (evt.event === 'playbook-stop')
+            this.playbookStopped(evt.playbook);
+          else if (evt.event === 'playbook-start')
+            this.playbookStarted(evt.playbook);
+          else if (evt.event === 'playbook-error')
+            this.playbookError(evt.playbook);
+        }
+      });
+  }
+
+  processPlaybooks = () => {
+    let playStatus = this.sumPlaybookProcessStatus();
+    let progressPlay = playStatus.in_progress;
+    let completePlaybooks = playStatus.complete;
+    let failedPlaybooks = playStatus.failed;
+
+    // if have last recorded in progress
+    if (progressPlay) {
+      // if have completes, process completed logs first
+      if(completePlaybooks.length > 0) {
+        completePlaybooks.forEach((book) => {
+          this.processAlreadyDonePlaybook(book, STATUS.COMPLETE);
+        });
+      }
+
+      //check the in progress one
+      fetchJson('/api/v1/clm/plays/' + progressPlay.playId, {
         // Note: Use no-cache in order to get an up-to-date response
         headers: {
           'pragma': 'no-cache',
@@ -175,77 +349,130 @@ class PlaybookProgress extends Component {
       })
         .then(response => {
           if ('endTime' in response) {
-            // The play has already ended, and is either complete or failed
-            this.props.updateStatus(response['code'] == 0 ? STATUS.COMPLETE : STATUS.FAILED);
+            let status = (response['code'] == 0 ? STATUS.COMPLETE : STATUS.FAILED);
+            // update logs
+            this.processAlreadyDonePlaybook(progressPlay, status);
+            // update global playbookStatus
+            this.updateGlobalPlaybookStatus(progressPlay.name, progressPlay.playId, status);
 
-            fetchJson('/api/v1/clm/plays/' + this.props.playId + '/log')
-              .then(response => {
-                const message = response.trimRight('\n');
-                this.logsReceived = List(message);
-                this.setState({displayedLogs: this.logsReceived});
-              });
-
-            fetchJson('/api/v1/clm/plays/' + this.props.playId + '/events')
-              .then(response => {
-                for (let evt of response) {
-                  if (evt.event === 'playbook-stop')
-                    this.playbookStopped(evt.playbook);
-                  else if (evt.event === 'playbook-start')
-                    this.playbookStarted(evt.playbook);
-                  else if (evt.event === 'playbook-error')
-                    this.playbookError(evt.playbook);
-                }
-              });
-          } else {
+            if (status === STATUS.COMPLETE) {
+              let nextPlaybookName = this.findNextPlaybook([progressPlay.name]);
+              if(nextPlaybookName) {
+                this.launchPlaybook(nextPlaybookName);
+              }
+              else {
+                this.props.updatePageStatus(STATUS.COMPLETE);
+              }
+            }
+            else { //failed
+              this.props.updatePageStatus(STATUS.FAILED);
+            }
+          }
+          else {
             // The play is still in progress
-            this.props.updateStatus(STATUS.IN_PROGRESS);
-            this.monitorSocket(this.props.playId);
+            this.props.updatePageStatus(STATUS.IN_PROGRESS);
+            this.monitorSocket(progressPlay.name, progressPlay.playId);
           }
         })
         .catch((error) => {
           this.setState({errorMsg: error.message});
-        });
-
-    } else {
-      //commit before launchPlayBook
-      const commitMessage = {'message': 'Committed via Ardana DayZero Installer'};
-      postJson('/api/v1/clm/model/commit', commitMessage)
-        .then((response) => {
-          this.setState({commit: 'succeed'});
-          this.launchPlaybook();
-        })
-        .catch((error) => {
-          this.setState({errorMsg: translate('deploy.commit.failure', error.toString())});
-          this.props.updateStatus(STATUS.FAILED);
-          this.setState({commit: 'fail'});
+          this.props.updatePageStatus(STATUS.FAILED);
         });
     }
-  };
+    else { //don't have in progress playbook
+      //recorded either have completes or failed playbooks or never started
+      if(completePlaybooks.length > 0 || failedPlaybooks.length > 0) {
+        if (failedPlaybooks.length > 0) {
+          // go for the logs for completed if have any first
+          if (completePlaybooks.length > 0) {
+            completePlaybooks.forEach((book) => {
+              this.processAlreadyDonePlaybook(book, STATUS.COMPLETE);
+            });
+          }
+          // for failed, don't continue running playbook at all
+          // only go for logs
+          failedPlaybooks.forEach((book) => {
+            this.processAlreadyDonePlaybook(book, STATUS.FAILED);
+          });
 
-  launchPlaybook = () => {
-    postJson('/api/v1/clm/playbooks/' + this.props.playbook,
+          this.props.updatePageStatus(STATUS.FAILED);
+        }
+        else { //don't have failed, just have complete books
+          // go for logs for completed
+          let bookNames = [];
+          completePlaybooks.forEach((book) => {
+            this.processAlreadyDonePlaybook(book, STATUS.COMPLETE);
+            bookNames.push(book.name); //saved the names for checking next playbook
+          });
+          let nextPlaybookName = this.findNextPlaybook(bookNames);
+          // if have more to run
+          if (nextPlaybookName) {
+            this.launchPlaybook(nextPlaybookName);
+          }
+          else {
+            this.props.updatePageStatus(STATUS.COMPLETE);
+          }
+        }
+      }
+      else {//don't have any recorded in progress, failed or complete books
+        // commit model if need to
+        if(this.state.commit !== undefined) {
+          if(this.state.commit === STATUS.NOT_STARTED) {
+            this.commitChanges().then(() => {
+              //do not launch playbook if we can not commit
+              if (this.state.commit === STATUS.COMPLETE) {
+                this.launchPlaybook(this.props.playbooks[0]);
+              }
+            });
+          }
+          else if (this.state.commit === STATUS.COMPLETE) {
+            // recorded commit succeeded, but haven't start anything yet
+            this.launchPlaybook(this.props.playbooks[0]);
+          }
+          else { //recorded commit failed, try to recommit
+            this.commitChanges().then(() => {
+              //do not launch playbook if we can not commit
+              if (this.state.commit === STATUS.COMPLETE) {
+                this.launchPlaybook(this.props.playbooks[0]);
+              }
+            });
+          }
+        }
+        else { //don't need to commit change, just launch first playbook, for example install
+          this.launchPlaybook(this.props.playbooks[0]);
+        }
+      }
+    }
+  }
+
+  launchPlaybook = (playbookName) => {
+    postJson('/api/v1/clm/playbooks/' + playbookName,
       JSON.stringify(this.props.payload || ''))
       .then(response => {
         const playId = response['id'];
-        this.monitorSocket(playId);
-        this.props.updateStatus(STATUS.IN_PROGRESS);
-        this.props.updatePlayId(playId);
+        this.monitorSocket(playbookName, playId);
+        // update local this.globalPlaybookStatus and also update global state playbookSatus
+        this.updateGlobalPlaybookStatus(playbookName, playId, STATUS.IN_PROGRESS);
+        // overall status for caller page
+        this.props.updatePageStatus(STATUS.IN_PROGRESS);
       })
       .catch((error) => {
-        this.props.updateStatus(STATUS.FAILED);
+        // overall status for caller, if failed, just stop
+        this.props.updatePageStatus(STATUS.FAILED);
+        // update local this.globalPlaybookStatus and also update global state playbookSatus
+        this.updateGlobalPlaybookStatus(playbookName, '', STATUS.FAILED);
         this.setState({errorMsg: List(error.message)});
       });
   }
 
   renderShowLogButton() {
     const logButtonLabel = translate('progress.show.log');
-    if (this.props.playId || this.state.contents) {
-      return (
-        <ActionButton type='link'
-          displayLabel={logButtonLabel}
-          clickAction={() => this.setState((prev) => { return {'showLog': !prev.showLog}; }) } />
-      );
-    }
+
+    return (
+      <ActionButton type='link'
+        displayLabel={logButtonLabel}
+        clickAction={() => this.setState((prev) => { return {'showLog': !prev.showLog}; }) } />
+    );
   }
 
   renderLogViewer() {
@@ -266,7 +493,7 @@ class PlaybookProgress extends Component {
           <div className='col-xs-4'>
             <ul>{this.getCommitStatus()}{this.getProgress()}</ul>
             <div>
-              {!this.state.showLog && this.renderShowLogButton()}
+              {!this.state.errorMsg && !this.state.showLog && this.renderShowLogButton()}
             </div>
           </div>
           <div className='col-xs-8'>
@@ -276,6 +503,11 @@ class PlaybookProgress extends Component {
         </div>
       </div>
     );
+  }
+
+  componentDidMount() {
+    this.globalPlaybookStatus = this.getGlobalPlaybookStatus();
+    this.processPlaybooks();
   }
 
   componentWillUnmount() {
@@ -295,9 +527,9 @@ class PlaybookProgress extends Component {
    * to the user
    * @param {String} the playbook filename
    */
-  playbookStarted = (playbook) => {
+  playbookStarted = (stepPlaybook) => {
     this.setState((prevState) => {
-      return {'playbooksStarted': prevState.playbooksStarted.concat(playbook)};
+      return {'playbooksStarted': prevState.playbooksStarted.concat(stepPlaybook)};
     });
   }
 
@@ -305,18 +537,21 @@ class PlaybookProgress extends Component {
    * callback for when a playbook finishes, the UI component will track which
    * playbooks out of the needed set have started/finished to show status
    * to the user
-   * @param {String} the playbook filename
+   *
+   * @param stepPlaybook
+   * @param playbookName
+   * @param playId
    */
-  playbookStopped = (playbook) => {
+  playbookStopped = (stepPlaybook, playbookName, playId) => {
     let complete = false;
 
     this.setState((prevState) => {
-      const completedPlaybooks = prevState.playbooksComplete.concat(playbook);
-      complete = completedPlaybooks.includes(this.props.playbook+'.yml');
+      const completedPlaybooks = prevState.playbooksComplete.concat(stepPlaybook);
+      complete = completedPlaybooks.includes(playbookName + '.yml');
       return {'playbooksComplete': completedPlaybooks};
     });
-    if (complete) {
-      this.props.updateStatus(STATUS.COMPLETE);
+    if (complete && playbookName) {
+      this.updateGlobalPlaybookStatus(playbookName, playId, STATUS.COMPLETE);
     }
   }
 
@@ -324,19 +559,26 @@ class PlaybookProgress extends Component {
    * callback for when a playbook finishes, the UI component will track which
    * playbooks out of the needed set have started/finished to show status
    * to the user
-   * @param {String} the playbook filename
+   *
+   * @param stepPlaybook
+   * @param playbookName
+   * @param playId
    */
-  playbookError = (playbook) => {
+  playbookError = (stepPlaybook, playbookName, playId) => {
     let failed = false;
 
     this.setState((prevState) => {
-      const errorPlaybooks = prevState.playbooksError.concat(playbook);
-      failed = errorPlaybooks.includes(this.props.playbook+'.yml');
+      const errorPlaybooks = prevState.playbooksError.concat(stepPlaybook);
+      failed = errorPlaybooks.includes(playbookName + '.yml');
       return {'playbooksError': errorPlaybooks};
     });
 
     if (failed) {
-      this.props.updateStatus(STATUS.FAILED);
+      if(playbookName) {
+        this.updateGlobalPlaybookStatus(playbookName, playId, STATUS.FAILED);
+      }
+      // if failed update caller page immediately
+      this.props.updatePageStatus(STATUS.FAILED);
     }
   }
 

--- a/src/localization/bundles/en.json
+++ b/src/localization/bundles/en.json
@@ -281,6 +281,9 @@
     "complete.message.link2": "Ops Console UI",
 
     "deploy.progress.heading": "Cloud Deployment In Progress",
+    "deploy.progress.config-processor-run": "Config Processor Run",
+    "deploy.progress.ready-deployment": "Ready Deployment",
+    "deploy.progress.predeployment": "Pre-Deployment",
     "deploy.progress.step1": "Network Configuration",
     "deploy.progress.step2": "Compute nodes deployed",
     "deploy.progress.step3": "Monitoring nodes deployed",

--- a/src/pages/CloudDeployProgress.js
+++ b/src/pages/CloudDeployProgress.js
@@ -28,8 +28,23 @@ import { PlaybookProgress } from '../components/PlaybookProcess.js';
   The play id is kept in the global state, and its absence indicates
   that the playbook should be launched.
 */
+const PRE_DEPLOYMENT_PLAYBOOK = 'dayzero-pre-deployment';
+const DAYZERO_SITE_PLAYBOOK = 'dayzero-site';
+const SITE_PLAYBOOK = 'site';
 
-const SITE_STEPS = [
+const PLAYBOOK_STEPS = [
+  {
+    label: translate('deploy.progress.config-processor-run'),
+    playbooks: ['config-processor-run.yml']
+  },
+  {
+    label: translate('deploy.progress.ready-deployment'),
+    playbooks: ['ready-deployment.yml']
+  },
+  {
+    label: translate('deploy.progress.predeployment'),
+    playbooks: ['dayzero-pre-deployment.yml', ]
+  },
   {
     label: translate('deploy.progress.step1'),
     playbooks: ['network_interface-deploy.yml']
@@ -53,7 +68,7 @@ const SITE_STEPS = [
   },
   {
     label: translate('deploy.progress.step6'),
-    playbooks: ['site.yml']
+    playbooks: ['site.yml', 'dayzero-site.yml'] //either site.yml or dayzero-site.yml
   }
 ];
 
@@ -69,18 +84,52 @@ class CloudDeployProgress extends BaseWizardPage {
   setNextButtonDisabled = () => this.state.overallStatus != STATUS.COMPLETE;
   setBackButtonDisabled = () => this.state.overallStatus != STATUS.FAILED;
 
-  updateStatus = (status) => {this.setState({overallStatus: status});}
-  updatePlayId = (playId) => {this.props.updateGlobalState('sitePlayId', playId);}
+  updatePageStatus = (status) => {
+    this.setState({overallStatus: status});
+  }
+
+  // Clear out the global playbookStatus entry for PRE_DEPLOYMENT_PLAYBOOK,
+  // DAYZERO_SITE_PLAYBOOK or SITE_PLAYBOOK and commitStatus
+  // which permits running the deploy multiple times when have errors and
+  // need to go back
+  resetPlaybookStatus = () => {
+    this.props.updateGlobalState('commitStatus', '');
+    if (this.props.playbookStatus) {
+      let playStatus = this.props.playbookStatus.slice();
+      playStatus.forEach((play, idx) => {
+        // remove the exist one
+        if (play.name === PRE_DEPLOYMENT_PLAYBOOK ||
+          play.name === DAYZERO_SITE_PLAYBOOK || play.name === SITE_PLAYBOOK) {
+          play.playId = '';
+          play.status = '';
+        }
+      });
+      this.props.updateGlobalState('playbookStatus', playStatus);
+    }
+  }
+
+  goForward(e) {
+    e.preventDefault();
+    this.props.updateGlobalState('deployConfig', undefined);
+    super.goForward(e);
+  }
+
+  goBack(e) {
+    e.preventDefault();
+    // reset so can rerun deploy if failed
+    this.resetPlaybookStatus();
+    super.goBack(e);
+  }
 
   render() {
     // choose between site or site with wipedisks (dayzero-site)
-    let sitePlaybook = 'site';
+    let sitePlaybook = SITE_PLAYBOOK;
 
     // Build the payload from the deployment configuration page options
     let payload = {};
     if (this.props.deployConfig) {
       if (this.props.deployConfig['wipeDisks']) {
-        sitePlaybook = 'dayzero-site';
+        sitePlaybook = DAYZERO_SITE_PLAYBOOK;
       }
       payload['verbose'] = this.props.deployConfig['verbosity'];
       payload['extraVars'] = {};
@@ -91,6 +140,11 @@ class CloudDeployProgress extends BaseWizardPage {
       }
     }
 
+    let commit = this.props.commitStatus; //global saved state
+    if(commit === undefined || commit === '') {
+      commit = STATUS.NOT_STARTED;
+    }
+
     return (
       <div className='wizard-page'>
         <div className='content-header'>
@@ -98,15 +152,10 @@ class CloudDeployProgress extends BaseWizardPage {
         </div>
         <div className='wizard-content'>
           <PlaybookProgress
-            overallStatus = {this.state.overallStatus}
-            updateStatus = {this.updateStatus}
-            playId = {this.props.sitePlayId}
-            updatePlayId = {this.updatePlayId}
-            steps = {SITE_STEPS}
-            deployConfig = {this.props.deployConfig}
-            playbook = {sitePlaybook}
-            payload = {payload}
-          />
+            updatePageStatus = {this.updatePageStatus} updateGlobalState = {this.props.updateGlobalState}
+            playbookStatus = {this.props.playbookStatus} commitStatus = {commit}
+            steps = {PLAYBOOK_STEPS} deployConfig = {this.props.deployConfig}
+            playbooks = {[PRE_DEPLOYMENT_PLAYBOOK, sitePlaybook]} payload = {payload}/>
         </div>
         {this.renderNavButtons()}
       </div>


### PR DESCRIPTION
This checkin includes:
1. Refactored PlaybookProcess to run multiple playbooks
2. Updated SelectServersToProvision to reflect the PlaybookProcess changes
3. Updated ConfigDeployProcess to reflect the PlaybookProcess changes
4. Preserved depolyConfig global state and delete it when move to end summary page
5.  Preserved playbookStatus and commitStatus global state.
For configureProcess, reset them  when go back after failure.
For provision, reset when go back